### PR TITLE
Fix flakey test by using catch instead of end

### DIFF
--- a/test/services/agent-service.test.ts
+++ b/test/services/agent-service.test.ts
@@ -56,9 +56,8 @@ describe('AgentService', () => {
 
       chai.request(`http://${host}`)
         .get('/percy-agent.js')
-        .end((error, _response) => {
-          expect(error).to.be.an('error')
-            .with.property('message', `connect ECONNREFUSED 127.0.0.1:${port}`)
+        .catch(async error => {
+          await expect(error).to.have.property('message', `connect ECONNREFUSED 127.0.0.1:${port}`)
         })
     })
 


### PR DESCRIPTION
Chai was not happy about seeing an uncaught error in the `end` block of a request, but we are explicitly expecting an error for this particular test.

Moving to a `catch` block makes the test more reliable and also removes a deprecation that will make this test fail every time in future version of chai.