### PR TITLE
Introduce .percy.yml configuration file for setting snapshot defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1393,7 +1393,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -3657,7 +3657,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "optional": true
     },
@@ -3906,7 +3906,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3958,7 +3958,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -5763,7 +5763,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "colors": "^1.3.2",
     "cors": "^2.8.4",
     "express": "^4.16.3",
+    "js-yaml": "^3.12.0",
     "percy-client": "^3.0.1",
     "puppeteer": "^1.7.0",
     "retry-axios": "^0.3.2",

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -7,7 +7,7 @@ import SnapshotService from './snapshot-service'
 import logger, {profile} from '../utils/logger'
 import ProcessService from './process-service'
 import {AgentOptions} from './agent-options'
-import configuration from '../utils/configuration'
+import configuration, {SnapshotConfiguration} from '../utils/configuration'
 
 export default class AgentService {
   readonly app: express.Application
@@ -74,14 +74,14 @@ export default class AgentService {
       request.body.domSnapshot,
     )
 
-    const conf = configuration()
+    const snapshotConfiguration = (configuration().snapshot || {}) as SnapshotConfiguration
 
     let snapshotCreation = this.snapshotService.create(
       request.body.name,
       resources,
-      request.body.enableJavascript || conf.snapshot.widths,
-      request.body.widths || conf.snapshot.widths,
-      request.body.minHeight || conf.snapshot['min-height'],
+      request.body.enableJavascript || snapshotConfiguration['enable-javascript'],
+      request.body.widths || snapshotConfiguration.widths,
+      request.body.minHeight || snapshotConfiguration['min-height'],
     )
 
     this.snapshotCreationPromises.push(snapshotCreation)

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -7,6 +7,7 @@ import SnapshotService from './snapshot-service'
 import logger, {profile} from '../utils/logger'
 import ProcessService from './process-service'
 import {AgentOptions} from './agent-options'
+import configuration from '../utils/configuration'
 
 export default class AgentService {
   readonly app: express.Application
@@ -73,12 +74,14 @@ export default class AgentService {
       request.body.domSnapshot,
     )
 
+    const conf = configuration()
+
     let snapshotCreation = this.snapshotService.create(
       request.body.name,
       resources,
-      request.body.enableJavascript,
-      request.body.widths,
-      request.body.minHeight,
+      request.body.enableJavascript || conf.snapshot.widths,
+      request.body.widths || conf.snapshot.widths,
+      request.body.minHeight || conf.snapshot['min-height'],
     )
 
     this.snapshotCreationPromises.push(snapshotCreation)

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -79,7 +79,7 @@ export default class AgentService {
     let snapshotCreation = this.snapshotService.create(
       request.body.name,
       resources,
-      request.body.enableJavascript || snapshotConfiguration['enable-javascript'],
+      request.body.enableJavascript,
       request.body.widths || snapshotConfiguration.widths,
       request.body.minHeight || snapshotConfiguration['min-height'],
     )

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -5,7 +5,6 @@ let path = require('path')
 export interface SnapshotConfiguration {
   widths?: [number],
   'min-height'?: number,
-  'enable-javascript'?: boolean
 }
 
 export interface Configuration {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -13,10 +13,10 @@ export interface Configuration {
 }
 
 let configuration = (relativePath = '.percy.yml'): Configuration => {
-  const confFilePath = path.join(process.cwd(), relativePath)
+  const configFilePath = path.join(process.cwd(), relativePath)
 
   try {
-    return yaml.safeLoad(fs.readFileSync(confFilePath, 'utf8'))
+    return yaml.safeLoad(fs.readFileSync(configFilePath, 'utf8'))
   } catch {
     // this is ok because we just use this configuration as one of the fallbacks
     // in a chain. snapshot specific options -> agent configuration -> default values

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -1,0 +1,17 @@
+let yaml = require('js-yaml')
+let fs = require('fs')
+import logger from './logger'
+
+let configuration = (): any => {
+  let conf = {}
+
+  try {
+    conf = yaml.safeLoad(fs.readFileSync('.percy,yml', 'utf8'))
+  } catch {
+    logger.warn('.percy.yml parse error')
+  }
+
+  return conf
+}
+
+export default configuration

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -1,17 +1,28 @@
 let yaml = require('js-yaml')
 let fs = require('fs')
+let path = require('path')
 
-interface Configuration {
-  version: number,
-  snapshot: {
-    widths?: [number],
-    'min-height'?: number,
-    'enable-javascript'?: boolean
-  }
+export interface SnapshotConfiguration {
+  widths?: [number],
+  'min-height'?: number,
+  'enable-javascript'?: boolean
 }
 
-let configuration = (filePath = '.percy.yml'): Configuration => {
-  return yaml.safeLoad(fs.readFileSync(filePath, 'utf8'))
+export interface Configuration {
+  version: number,
+  snapshot: SnapshotConfiguration
+}
+
+let configuration = (relativePath = '.percy.yml'): Configuration => {
+  const confFilePath = path.join(process.cwd(), relativePath)
+
+  try {
+    return yaml.safeLoad(fs.readFileSync(confFilePath, 'utf8'))
+  } catch {
+    // this is ok because we just use this configuration as one of the fallbacks
+    // in a chain. snapshot specific options -> agent configuration -> default values
+    return {} as Configuration
+  }
 }
 
 export default configuration

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -2,13 +2,22 @@ let yaml = require('js-yaml')
 let fs = require('fs')
 import logger from './logger'
 
-let configuration = (): any => {
-  let conf = {}
+interface Configuration {
+  version: number,
+  snapshot: {
+    widths?: [number],
+    'min-height'?: number,
+    'enable-javascript'?: boolean
+  }
+}
+
+let configuration = (filePath = '.percy.yml'): Configuration => {
+  let conf = {} as Configuration
 
   try {
-    conf = yaml.safeLoad(fs.readFileSync('.percy,yml', 'utf8'))
+    conf = yaml.safeLoad(fs.readFileSync(filePath, 'utf8'))
   } catch {
-    logger.warn('.percy.yml parse error')
+    logger.warn('.percy.yml parse error!')
   }
 
   return conf

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -1,6 +1,5 @@
 let yaml = require('js-yaml')
 let fs = require('fs')
-import logger from './logger'
 
 interface Configuration {
   version: number,
@@ -12,15 +11,7 @@ interface Configuration {
 }
 
 let configuration = (filePath = '.percy.yml'): Configuration => {
-  let conf = {} as Configuration
-
-  try {
-    conf = yaml.safeLoad(fs.readFileSync(filePath, 'utf8'))
-  } catch {
-    logger.warn('.percy.yml parse error!')
-  }
-
-  return conf
+  return yaml.safeLoad(fs.readFileSync(filePath, 'utf8'))
 }
 
 export default configuration

--- a/test/support/.percy-invalid.yml
+++ b/test/support/.percy-invalid.yml
@@ -1,1 +1,0 @@
-hello: I'm invalid

--- a/test/support/.percy-invalid.yml
+++ b/test/support/.percy-invalid.yml
@@ -1,0 +1,1 @@
+hello: I'm invalid

--- a/test/support/.percy.yml
+++ b/test/support/.percy.yml
@@ -1,0 +1,5 @@
+version: 1
+snapshot:
+  widths: [375, 1280]
+  min-height: 1024
+  enable-javascript: false

--- a/test/support/.percy.yml
+++ b/test/support/.percy.yml
@@ -2,4 +2,3 @@ version: 1
 snapshot:
   widths: [375, 1280]
   min-height: 1024
-  enable-javascript: false

--- a/test/utils/configuration.test.ts
+++ b/test/utils/configuration.test.ts
@@ -2,12 +2,20 @@ import {expect} from 'chai'
 import configuration from '../../src/utils/configuration'
 
 describe('Configuration', () => {
-  it('parsing the configuration', () => {
+  it('parses valid configuration', () => {
     const subject = configuration('test/support/.percy.yml')
 
     expect(subject.version).to.eql(1)
     expect(subject.snapshot.widths).to.eql([375, 1280])
     expect(subject.snapshot['min-height']).to.eql(1024)
     expect(subject.snapshot['enable-javascript']).to.eql(false)
+  })
+
+  it('gracefully handles missing data', () => {
+    const subject = configuration('test/support/.percy-invalid.yml')
+
+    // this is ok because we just use this configuration as one of the fallbacks
+    // in a chain. snapshot specific options -> agent configuration -> default values
+    expect(subject.snapshot).to.eql(undefined)
   })
 })

--- a/test/utils/configuration.test.ts
+++ b/test/utils/configuration.test.ts
@@ -11,11 +11,9 @@ describe('Configuration', () => {
     expect(subject.snapshot['enable-javascript']).to.eql(false)
   })
 
-  it('gracefully handles missing data', () => {
-    const subject = configuration('test/support/.percy-invalid.yml')
+  it('gracefully handles a missing file', () => {
+    const subject = configuration('test/support/.file-does-not-exit.yml')
 
-    // this is ok because we just use this configuration as one of the fallbacks
-    // in a chain. snapshot specific options -> agent configuration -> default values
-    expect(subject.snapshot).to.eql(undefined)
+    expect(subject).to.eql({})
   })
 })

--- a/test/utils/configuration.test.ts
+++ b/test/utils/configuration.test.ts
@@ -1,0 +1,13 @@
+import {expect} from 'chai'
+import configuration from '../../src/utils/configuration'
+
+describe('Configuration', () => {
+  it('parsing the configuration', () => {
+    const subject = configuration('test/support/.percy.yml')
+
+    expect(subject.version).to.eql(1)
+    expect(subject.snapshot.widths).to.eql([375, 1280])
+    expect(subject.snapshot['min-height']).to.eql(1024)
+    expect(subject.snapshot['enable-javascript']).to.eql(false)
+  })
+})

--- a/test/utils/configuration.test.ts
+++ b/test/utils/configuration.test.ts
@@ -8,7 +8,6 @@ describe('Configuration', () => {
     expect(subject.version).to.eql(1)
     expect(subject.snapshot.widths).to.eql([375, 1280])
     expect(subject.snapshot['min-height']).to.eql(1024)
-    expect(subject.snapshot['enable-javascript']).to.eql(false)
   })
 
   it('gracefully handles a missing file', () => {

--- a/test/utils/configuration.test.ts
+++ b/test/utils/configuration.test.ts
@@ -12,7 +12,7 @@ describe('Configuration', () => {
   })
 
   it('gracefully handles a missing file', () => {
-    const subject = configuration('test/support/.file-does-not-exit.yml')
+    const subject = configuration('test/support/.file-does-not-exist.yml')
 
     expect(subject).to.eql({})
   })


### PR DESCRIPTION
This PR allows the user to create a `.percy.yml` file like this:

```yaml
version: 1
snapshot:
  widths: [375, 1280]
  min-height: 1024
  enable-javascript: false
```

This configuration will be picked up as the default options when taking a snapshot. This is particularly useful for setting default snapshot widths across for your entire build.

The configuration file needs to be created in the directory the `percy` command is being run. For now, `.percy.yml` is hardcoded as the filename. Potentially in the future we'll have a flag which will allow you to point to any file on disk to be used for the configuration.