### PR TITLE
Gracefully handle missing tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ EXAMPLE
   [percy] Finalized parallel build.
 ```
 
+_See code: [dist/commands/finalize.ts](https://github.com/percy/percy-agent/blob/v0.0.50/dist/commands/finalize.ts)_
+
 ## `percy help [COMMAND]`
 
 display help for percy

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -42,19 +42,20 @@ export default class Exec extends PercyCommand {
       return
     }
 
-    await this.agentService.start({port, networkIdleTimeout})
-    this.logStart()
+    if (this.percyWillRun()) {
+      await this.agentService.start({port, networkIdleTimeout})
+      this.logStart()
+    }
 
+    // Even if Percy will not run, continue to run the subprocess
     const spawnedProcess = spawn(command, argv, {stdio: 'inherit'})
 
     spawnedProcess.on('exit', async (code: any) => {
-      if (!this.percyEnvVarsMissing()) {
+      if (this.percyWillRun()) {
         await this.agentService.stop()
       }
 
       process.exit(code)
     })
-
-    spawnedProcess.unref()
   }
 }

--- a/src/commands/finalize.ts
+++ b/src/commands/finalize.ts
@@ -21,6 +21,8 @@ export default class Finalize extends PercyCommand {
   async run() {
     await super.run()
 
+    if (!this.percyWillRun()) { this.exit(0) }
+
     this.parse(Finalize)
 
     const result = await this.buildService.finalizeAll()

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -22,12 +22,8 @@ export default class PercyCommand extends Command {
   }
 
   async run() {
-    if (!this.percyEnabled()) {
-      this.exit(0)
-    }
-
-    if (this.percyEnvVarsMissing()) {
-      this.exit(1)
+    if (this.percyEnabled && !this.percyTokenPresent()) {
+      this.logMissingEnvVar('PERCY_TOKEN')
     }
   }
 
@@ -35,13 +31,12 @@ export default class PercyCommand extends Command {
     return process.env.PERCY_ENABLE !== '0'
   }
 
-  percyEnvVarsMissing(): boolean {
-    if (this.percyToken === '') {
-      this.logMissingEnvVar('PERCY_TOKEN')
-      return true
-    }
+  percyWillRun(): boolean {
+    return (this.percyEnabled() && this.percyTokenPresent())
+  }
 
-    return false
+  percyTokenPresent(): boolean {
+    return this.percyToken !== ''
   }
 
   logStart() {
@@ -49,6 +44,6 @@ export default class PercyCommand extends Command {
   }
 
   logMissingEnvVar(name: string) {
-    this.error(`You must set ${name}`, {exit: 1})
+    this.warn(`You must set ${name}`)
   }
 }

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -23,7 +23,7 @@ export default class PercyCommand extends Command {
 
   async run() {
     if (this.percyEnabled && !this.percyTokenPresent()) {
-      this.warn('Skipping visual tests. You must set PERCY_TOKEN')
+      this.warn('Skipping visual tests. PERCY_TOKEN was not provided.')
     }
   }
 

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -36,7 +36,7 @@ export default class PercyCommand extends Command {
   }
 
   percyTokenPresent(): boolean {
-    return this.percyToken !== ''
+    return this.percyToken.trim() !== ''
   }
 
   logStart() {

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -23,7 +23,7 @@ export default class PercyCommand extends Command {
 
   async run() {
     if (this.percyEnabled && !this.percyTokenPresent()) {
-      this.logMissingEnvVar('PERCY_TOKEN')
+      this.warn('Skipping visual tests, You must set PERCY_TOKEN')
     }
   }
 
@@ -41,9 +41,5 @@ export default class PercyCommand extends Command {
 
   logStart() {
     this.logger.info('percy has started.')
-  }
-
-  logMissingEnvVar(name: string) {
-    this.warn(`You must set ${name}`)
   }
 }

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -23,7 +23,7 @@ export default class PercyCommand extends Command {
 
   async run() {
     if (this.percyEnabled && !this.percyTokenPresent()) {
-      this.warn('Skipping visual tests, You must set PERCY_TOKEN')
+      this.warn('Skipping visual tests. You must set PERCY_TOKEN')
     }
   }
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -34,6 +34,9 @@ export default class Start extends PercyCommand {
   async run() {
     await super.run()
 
+    // If Percy is disabled or is missing a token, gracefully exit here
+    if (!this.percyWillRun()) { this.exit(0) }
+
     const {flags} = this.parse(Start)
     let port = flags.port as number
     let networkIdleTimeout = flags['network-idle-timeout'] as number

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -23,6 +23,9 @@ export default class Stop extends PercyCommand {
   async run() {
     await super.run()
 
+    // If Percy is disabled or is missing a token, gracefully exit here
+    if (!this.percyWillRun()) { this.exit(0) }
+
     const {flags} = this.parse(Stop)
     const port = flags.port ? flags.port : 5338
 

--- a/src/percy-agent-client/percy-agent-client.ts
+++ b/src/percy-agent-client/percy-agent-client.ts
@@ -1,13 +1,36 @@
 export class PercyAgentClient {
   xhr: XMLHttpRequest
+  agentHost: string
+  agentConnected = false
 
-  constructor(xhr?: any) {
+  constructor(agentHost: string, xhr?: any) {
+    this.agentHost = agentHost
     this.xhr = new xhr() || new XMLHttpRequest()
+    this.healthCheck()
   }
 
-  post(url: string, data: any) {
-    this.xhr.open('post', url, false) // synchronous request
+  post(path: string, data: any) {
+    if (!this.agentConnected) {
+      console.warn('percy agent not started.')
+      return
+    }
+
+    this.xhr.open('post', `${this.agentHost}${path}`, false) // synchronous request
     this.xhr.setRequestHeader('Content-Type', 'application/json')
     this.xhr.send(JSON.stringify(data))
+  }
+
+  healthCheck() {
+    try {
+      this.xhr.open('get', `${this.agentHost}/percy/healthcheck`, false)
+      this.xhr.onload = () => {
+        if (this.xhr.status === 200) {
+          this.agentConnected = true
+        }
+      }
+      this.xhr.send()
+    } catch {
+      this.agentConnected = false
+    }
   }
 }

--- a/src/percy-agent-client/percy-agent.ts
+++ b/src/percy-agent-client/percy-agent.ts
@@ -8,6 +8,8 @@ export default class PercyAgent {
   xhr: any
   port: number
   domTransformation: any | null
+  client: PercyAgentClient
+
   readonly defaultDoctype = '<!DOCTYPE html>'
 
   constructor(options: ClientOptions = {}) {
@@ -16,18 +18,18 @@ export default class PercyAgent {
     this.xhr = options.xhr || XMLHttpRequest
     this.domTransformation = options.domTransformation || null
     this.port = options.port || 5338
-  }
 
-  _agentHost(): string {
-    return `http://localhost:${this.port}`
+    this.client = new PercyAgentClient(
+      `http://localhost:${this.port}`,
+      this.xhr
+    )
   }
 
   snapshot(name: string, options: SnapshotOptions = {}) {
     let documentObject = options.document || document
     let domSnapshot = this.domSnapshot(documentObject)
-    let percyAgentClient = new PercyAgentClient(this._agentHost(), this.xhr)
 
-    percyAgentClient.post('/percy/snapshot', {
+    this.client.post('/percy/snapshot', {
       name,
       url: documentObject.URL,
       enableJavascript: options.enableJavascript,

--- a/src/percy-agent-client/percy-agent.ts
+++ b/src/percy-agent-client/percy-agent.ts
@@ -18,12 +18,16 @@ export default class PercyAgent {
     this.port = options.port || 5338
   }
 
+  _agentHost(): string {
+    return `http://localhost:${this.port}`
+  }
+
   snapshot(name: string, options: SnapshotOptions = {}) {
     let documentObject = options.document || document
     let domSnapshot = this.domSnapshot(documentObject)
-    let percyAgentClient = new PercyAgentClient(this.xhr)
+    let percyAgentClient = new PercyAgentClient(this._agentHost(), this.xhr)
 
-    percyAgentClient.post(`http://localhost:${this.port}/percy/snapshot`, {
+    percyAgentClient.post('/percy/snapshot', {
       name,
       url: documentObject.URL,
       enableJavascript: options.enableJavascript,

--- a/test/commands/finalize.test.ts
+++ b/test/commands/finalize.test.ts
@@ -10,7 +10,7 @@ describe('finalize', () => {
       ' -a, --all\n' +
       'See more help with --help'
     ))
-    .it('requires -all flag')
+    .it('requires --all flag')
 
   test
     .command(['finalize'])

--- a/test/commands/percy-command.test.ts
+++ b/test/commands/percy-command.test.ts
@@ -6,7 +6,7 @@ describe('percy-command', () => {
     .stderr()
     .command(['percy-command'])
     .do(output => expect(output.stderr).to.contain(
-      'Warning: You must set PERCY_TOKEN'
+      'Warning: Skipping visual tests. You must set PERCY_TOKEN'
     ))
     .it('warns about PERCY_TOKEN to be set')
 
@@ -15,7 +15,7 @@ describe('percy-command', () => {
     .stderr()
     .command(['percy-command'])
     .do(output => expect(output.stderr).to.contain(
-      'Warning: You must set PERCY_TOKEN'
+      'Warning: Skipping visual tests. You must set PERCY_TOKEN'
     ))
     .it('warns about PERCY_TOKEN to be set')
 

--- a/test/commands/percy-command.test.ts
+++ b/test/commands/percy-command.test.ts
@@ -6,7 +6,7 @@ describe('percy-command', () => {
     .stderr()
     .command(['percy-command'])
     .do(output => expect(output.stderr).to.contain(
-      'Warning: Skipping visual tests. You must set PERCY_TOKEN'
+      'Warning: Skipping visual tests. PERCY_TOKEN was not provided.'
     ))
     .it('warns about PERCY_TOKEN to be set')
 
@@ -15,7 +15,7 @@ describe('percy-command', () => {
     .stderr()
     .command(['percy-command'])
     .do(output => expect(output.stderr).to.contain(
-      'Warning: Skipping visual tests. You must set PERCY_TOKEN'
+      'Warning: Skipping visual tests. PERCY_TOKEN was not provided.'
     ))
     .it('warns about PERCY_TOKEN to be set')
 

--- a/test/commands/percy-command.test.ts
+++ b/test/commands/percy-command.test.ts
@@ -5,20 +5,24 @@ describe('percy-command', () => {
     .stub(process, 'env', {PERCY_TOKEN: ''})
     .stderr()
     .command(['percy-command'])
-    .catch(err => expect(err.message).to.equal(
-      'You must set PERCY_TOKEN'
+    .do(output => expect(output.stderr).to.contain(
+      'Warning: You must set PERCY_TOKEN'
     ))
-    .it('requires PERCY_TOKEN to be set')
-
-  test
-    .stub(process, 'env', {PERCY_TOKEN: ''})
-    .command(['percy-command'])
-    .exit(1)
-    .it('exits with code 1')
+    .it('warns about PERCY_TOKEN to be set')
 
   test
     .stub(process, 'env', {PERCY_ENABLE: '0', PERCY_TOKEN: ''})
+    .stderr()
     .command(['percy-command'])
-    .exit(0)
-    .it('exits with code 0')
+    .do(output => expect(output.stderr).to.contain(
+      'Warning: You must set PERCY_TOKEN'
+    ))
+    .it('warns about PERCY_TOKEN to be set')
+
+  test
+    .stub(process, 'env', {PERCY_ENABLE: '0', PERCY_TOKEN: 'ABC'})
+    .stderr()
+    .command(['percy-command'])
+    .do(output => expect(output.stderr).to.eql(''))
+    .it('outputs no errors')
 })

--- a/test/percy-agent-client/percy-agent.test.ts
+++ b/test/percy-agent-client/percy-agent.test.ts
@@ -6,7 +6,7 @@ require('../../src/percy-agent-client/percy-agent')
 describe('PercyAgent', () => {
   let requests: sinon.SinonFakeXMLHttpRequest[] = []
   let subject: PercyAgent
-  let xhr: sinon.SinonFakeXMLHttpRequest
+  let xhr: any
 
   beforeEach(() => {
     xhr = sinon.useFakeXMLHttpRequest()

--- a/test/percy-agent-client/percy-agent.test.ts
+++ b/test/percy-agent-client/percy-agent.test.ts
@@ -1,24 +1,29 @@
 import {expect} from 'chai'
 import PercyAgent from '../../src/percy-agent-client/percy-agent'
-require('../../src/percy-agent-client/percy-agent')
 import * as sinon from 'sinon'
+require('../../src/percy-agent-client/percy-agent')
 
 describe('PercyAgent', () => {
-  let xhr = sinon.useFakeXMLHttpRequest()
-  const subject = new PercyAgent({
-    clientInfo: 'Test Client',
-    xhr
-  })
   let requests: sinon.SinonFakeXMLHttpRequest[] = []
+  let subject: PercyAgent
+  let xhr: sinon.SinonFakeXMLHttpRequest
 
   beforeEach(() => {
-    xhr.onCreate = xhrRequest => {
+    xhr = sinon.useFakeXMLHttpRequest()
+    xhr.onCreate = (xhrRequest: any) => {
       requests.push(xhrRequest)
     }
+
+    subject = new PercyAgent({
+      clientInfo: 'Test Client',
+      xhr
+    })
+
+    subject.client.agentConnected = true
   })
 
   afterEach(() => {
-    // xhr.restore
+    xhr.restore()
     requests = []
   })
 


### PR DESCRIPTION
When a token is provided, we create a build and run the subprocess.

```bash
$ PERCY_TOKEN=abc percy exec -- echo "hello"
[percy] created build #3209: https://percy.io/test/test/builds/1146012
[percy] percy has started.
hello
[percy] stopping percy...
[percy] waiting for 0 snapshots to complete...
[percy] done.
[percy] finalized build #3209: https://percy.io/test/test/builds/1146012
$ echo $?
0
```

When a token is not provided, we warn the token is missing and continue to run the subprocess.

```bash
$ PERCY_TOKEN= percy exec -- echo "hello"
 ›   Warning: Skipping visual tests, You must set PERCY_TOKEN
hello
$ echo $?
0
```

Pending an update to the Cypress SDK itself, this will help resolve https://github.com/percy/percy-cypress/issues/3