### PR TITLE
Ensure resources are unique by resourceUrl

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -2,7 +2,6 @@ import PercyClientService from './percy-client-service'
 import ResponseService from './response-service'
 import logger, {logError, profile} from '../utils/logger'
 import * as puppeteer from 'puppeteer'
-import unique from '../utils/unique-array'
 import waitForNetworkIdle from '../utils/wait-for-network-idle'
 
 interface AssetDiscoveryOptions {
@@ -81,7 +80,15 @@ export default class AssetDiscoveryService extends PercyClientService {
 
     this.page.removeAllListeners()
 
-    resources = unique(resources)
+    let resourceUrls: string[] = []
+
+    resources = resources.filter((resource: any) => {
+      if (!resourceUrls.includes(resource.resourceUrl)) {
+        resourceUrls.push(resource.resourceUrl as string)
+        return true
+      }
+      return false
+    })
 
     profile('-> assetDiscoveryService.discoverResources', {resourcesDiscovered: resources.length})
 

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -82,6 +82,7 @@ export default class AssetDiscoveryService extends PercyClientService {
 
     let resourceUrls: string[] = []
 
+    // Dedup by resourceUrl as they must be unique when sent to Percy API down the line.
     resources = resources.filter((resource: any) => {
       if (!resourceUrls.includes(resource.resourceUrl)) {
         resourceUrls.push(resource.resourceUrl as string)

--- a/src/utils/unique-array.ts
+++ b/src/utils/unique-array.ts
@@ -1,5 +1,0 @@
-let unique = (rawArray: Array<any>): Array<any> => {
-  return Array.from(new Set(rawArray))
-}
-
-export default unique


### PR DESCRIPTION
Ensure resources are unique by `resourceUrl` specifically not by the whole resource object.

This bug has allowed some duplicated resources through to our API which results in an error like this:

```
[percy] StatusCodeError 400 - {“errors”:[{“status”:“bad_request”,“detail”:“Attempted to upload multiple resources with the same resource-url: \nhttps://x.com/y.jpg”}]}
```

Resources like this have the same `resourceUrl` but some other bit of the resource object was different and so it was allowed to be included.