### PR TITLE
Fix asset discovery loop timeout

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -51,7 +51,7 @@ export default class AssetDiscoveryService extends PercyClientService {
     let resources: any[] = []
 
     this.page.on('request', async request => {
-      if (request.isNavigationRequest()) {
+      if (request.url() === rootResourceUrl) {
         await request.respond({
           status: 200,
           contentType: 'text/html',


### PR DESCRIPTION
`isNavigationRequest` is true on more than one page load sometimes and that causes a loop of dom injection. This avoids that by checking the url against the rootResourceUrl instead.