### PR TITLE
Remove default widths and allow our API to select them instead

### DIFF
--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -12,7 +12,6 @@ export default class SnapshotService extends PercyClientService {
   resourceService: ResourceService
 
   buildId: number
-  readonly defaultWidths = [1280]
 
   constructor(buildId: number, options: SnapshotServiceOptions = {}) {
     super()
@@ -49,7 +48,7 @@ export default class SnapshotService extends PercyClientService {
     name: string,
     resources: any[],
     enableJavaScript = false,
-    widths: number[] = this.defaultWidths,
+    widths: number[] | null = null,
     minHeight: number | null = null,
   ): Promise<any> {
     const snapshotCreationPromise: Promise<any> = this.percyClient.createSnapshot(


### PR DESCRIPTION
Resolves [this clubhouse story](https://app.clubhouse.io/percy/story/2508/percy-agent-default-widths) by simply sending `null` widths onto our API, which in turn decides what the defaults are.

I've tested this and not specifying widths results in our API defaults and specifying widths continues to work.