### PR TITLE
Disable JavaScript when loading pages for asset discovery

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -35,6 +35,7 @@ export default class AssetDiscoveryService extends PercyClientService {
     profile('-> assetDiscoveryService.browser.newPage')
     this.page = await this.browser.newPage()
     await this.page.setRequestInterception(true)
+    await this.page.setJavaScriptEnabled(false)
     profile('-> assetDiscoveryService.browser.newPage')
   }
 


### PR DESCRIPTION
This is OK because the fully loaded DOM is already captured and we should have all the information required to watch the network as the page loads and capture resources.

It should yield a bit of a performance boost and help pages settle sooner but I haven't done any performance testing on this.

I have tested this on local and live websites and all assets are captured as you would expect.