### PR TITLE
Enable JS in asset discovery when the snapshot itself has JS enabled

### DIFF
--- a/src/percy-agent-client/percy-agent.ts
+++ b/src/percy-agent-client/percy-agent.ts
@@ -32,8 +32,10 @@ export default class PercyAgent {
     this.client.post('/percy/snapshot', {
       name,
       url: documentObject.URL,
+      // enableJavascript is deprecated. Use enableJavaScript
       enableJavaScript: options.enableJavaScript || options.enableJavascript,
       widths: options.widths,
+      // minimumHeight is deprecated. Use minHeight
       minHeight: options.minHeight || options.minimumHeight,
       clientInfo: this.clientInfo,
       environmentInfo: this.environmentInfo,

--- a/src/percy-agent-client/percy-agent.ts
+++ b/src/percy-agent-client/percy-agent.ts
@@ -32,7 +32,7 @@ export default class PercyAgent {
     this.client.post('/percy/snapshot', {
       name,
       url: documentObject.URL,
-      enableJavascript: options.enableJavascript,
+      enableJavaScript: options.enableJavaScript || options.enableJavascript,
       widths: options.widths,
       minHeight: options.minHeight || options.minimumHeight,
       clientInfo: this.clientInfo,

--- a/src/percy-agent-client/snapshot-options.ts
+++ b/src/percy-agent-client/snapshot-options.ts
@@ -1,4 +1,5 @@
 export interface SnapshotOptions {
+  enableJavaScript?: boolean,
   enableJavascript?: boolean,
   widths?: number[],
   minHeight?: number,

--- a/src/percy-agent-client/snapshot-options.ts
+++ b/src/percy-agent-client/snapshot-options.ts
@@ -1,8 +1,8 @@
 export interface SnapshotOptions {
   enableJavaScript?: boolean,
-  enableJavascript?: boolean,
+  enableJavascript?: boolean, // deprecated. Use enableJavaScript
   widths?: number[],
   minHeight?: number,
-  minimumHeight?: number,
+  minimumHeight?: number, // deprecated. Use minHeight
   document?: Document,
 }

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -70,6 +70,7 @@ export default class AgentService {
     const resources = await this.snapshotService.buildResources(
       request.body.url,
       request.body.domSnapshot,
+      request.body.enableJavaScript,
     )
 
     const snapshotConfiguration = (configuration().snapshot || {}) as SnapshotConfiguration
@@ -77,7 +78,7 @@ export default class AgentService {
     const snapshotCreation = this.snapshotService.create(
       request.body.name,
       resources,
-      request.body.enableJavascript,
+      request.body.enableJavaScript,
       request.body.widths || snapshotConfiguration.widths,
       request.body.minHeight || snapshotConfiguration['min-height'],
       request.body.clientInfo,

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -35,6 +35,7 @@ export default class AssetDiscoveryService extends PercyClientService {
     profile('-> assetDiscoveryService.browser.newPage')
     this.page = await this.browser.newPage()
     await this.page.setRequestInterception(true)
+    await this.page.setJavaScriptEnabled(false)
     profile('-> assetDiscoveryService.browser.newPage')
   }
 

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -35,11 +35,11 @@ export default class AssetDiscoveryService extends PercyClientService {
     profile('-> assetDiscoveryService.browser.newPage')
     this.page = await this.browser.newPage()
     await this.page.setRequestInterception(true)
-    await this.page.setJavaScriptEnabled(false)
+
     profile('-> assetDiscoveryService.browser.newPage')
   }
 
-  async discoverResources(rootResourceUrl: string, domSnapshot: string): Promise<any[]> {
+  async discoverResources(rootResourceUrl: string, domSnapshot: string, enableJavaScript = false): Promise<any[]> {
     profile('-> assetDiscoveryService.discoverResources')
 
     if (!this.browser || !this.page) {
@@ -52,6 +52,8 @@ export default class AssetDiscoveryService extends PercyClientService {
     logger.debug(`discovering assets for URL: ${rootResourceUrl}`)
 
     let resources: any[] = []
+
+    await this.page.setJavaScriptEnabled(enableJavaScript)
 
     this.page.on('request', async (request) => {
       if (request.url() === rootResourceUrl) {

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -28,6 +28,7 @@ export default class SnapshotService extends PercyClientService {
   async buildResources(
     rootResourceUrl: string,
     domSnapshot = '',
+    enableJavaScript = false,
   ): Promise<any[]> {
     const rootResource = await this.percyClient.makeResource({
       resourceUrl: rootResourceUrl,
@@ -37,7 +38,11 @@ export default class SnapshotService extends PercyClientService {
     })
 
     let resources: any[] = []
-    const discoveredResources = await this.assetDiscoveryService.discoverResources(rootResourceUrl, domSnapshot)
+    const discoveredResources = await this.assetDiscoveryService.discoverResources(
+      rootResourceUrl,
+      domSnapshot,
+      enableJavaScript,
+    )
     resources = resources.concat([rootResource])
     resources = resources.concat(discoveredResources)
 

--- a/test/percy-agent-client/percy-agent.test.ts
+++ b/test/percy-agent-client/percy-agent.test.ts
@@ -38,6 +38,23 @@ describe('PercyAgent', () => {
       expect(requestBody.name).to.equal('test snapshot')
     })
 
+    it('posts the percy agent process with options', () => {
+      subject.snapshot(
+        'test snapshot with options',
+        {enableJavaScript: true, widths: [320, 1024], minHeight: 512},
+      )
+
+      const request = requests[0]
+      const requestBody = JSON.parse(request.requestBody)
+
+      expect(request.url).to.equal('http://localhost:5338/percy/snapshot')
+      expect(request.method).to.equal('post')
+      expect(requestBody.name).to.equal('test snapshot with options')
+      expect(requestBody.enableJavaScript).to.equal(true)
+      expect(requestBody.widths).to.eql([320, 1024])
+      expect(requestBody.minHeight).to.equal(512)
+    })
+
     it('serializes text input elements', () => {
       const inputName = document.getElementById('testInputText') as HTMLInputElement
       inputName.value = 'test input value'


### PR DESCRIPTION
I've added some test coverage too for when snapshot calls are made with options.

This PR also renames `enableJavascript` to `enableJavaScript` but supports both. Eventually we should deprecate `enableJavascript`.