### PR TITLE
Fix percy build error breaking ci

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -36,11 +36,16 @@ export default class AgentService {
   }
 
   async start(options: AgentOptions = {}) {
-    this.server = this.app.listen(options.port)
-
     this.buildId = await this.buildService.create()
-    this.snapshotService = new SnapshotService(this.buildId, {networkIdleTimeout: options.networkIdleTimeout})
-    await this.snapshotService.assetDiscoveryService.setup()
+
+    if (this.buildId !== null) {
+      this.server = this.app.listen(options.port)
+      this.snapshotService = new SnapshotService(this.buildId, {networkIdleTimeout: options.networkIdleTimeout})
+      await this.snapshotService.assetDiscoveryService.setup()
+      return
+    }
+
+    await this.stop()
   }
 
   async stop() {

--- a/src/services/build-service.ts
+++ b/src/services/build-service.ts
@@ -7,20 +7,25 @@ export default class BuildService extends PercyClientService {
   buildNumber: number | null = null
   buildId: number | null = null
 
-  async create(): Promise<number> {
-    const build = await this.percyClient
-      .createBuild()
-      .catch(logError)
+  async create(): Promise<number | null> {
+    try {
+      const build = await this.percyClient
+        .createBuild()
 
-    const buildData = build.body.data
+      const buildData = build.body.data
 
-    this.buildId = parseInt(buildData.id) as number
-    this.buildNumber = parseInt(buildData.attributes['build-number'])
-    this.buildUrl = buildData.attributes['web-url']
+      this.buildId = parseInt(buildData.id) as number
+      this.buildNumber = parseInt(buildData.attributes['build-number'])
+      this.buildUrl = buildData.attributes['web-url']
 
-    this.logEvent('created')
+      this.logEvent('created')
 
-    return this.buildId
+      return this.buildId
+    } catch (e) {
+      logError(e)
+    }
+
+    return null
   }
 
   async finalize() {


### PR DESCRIPTION
CI and percy run on seperate status checking in PR, so we don't need
percy build to execute for the test suite to run.

This allows builds to proceed even if percy is down, this allows the
setting of proceeding with the build to be done through percy build
hooks rather than in the CI.