### PR TITLE
Add missing block return, avoid trying to double-handle the request

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -66,6 +66,7 @@ export default class AssetDiscoveryService extends PercyClientService {
           contentType: 'text/html',
           status: 200,
         })
+        return
       }
 
       await request.continue()


### PR DESCRIPTION
Caught and verified fix while working on `@percy/puppeteer`.