### PR TITLE
Use SnapshotOptions for passing around things like enableJavaScript

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -2,6 +2,7 @@ import * as bodyParser from 'body-parser'
 import * as cors from 'cors'
 import * as express from 'express'
 import {Server} from 'http'
+import { SnapshotOptions } from '../percy-agent-client/snapshot-options'
 import configuration, {SnapshotConfiguration} from '../utils/configuration'
 import logger, {profile} from '../utils/logger'
 import {AgentOptions} from './agent-options'
@@ -68,20 +69,23 @@ export default class AgentService {
 
     if (!this.snapshotService) { return response.json({success: false}) }
 
+    const snapshotConfiguration = (configuration().snapshot || {}) as SnapshotConfiguration
+    const snapshotOptions: SnapshotOptions = {
+      widths: request.body.widths || snapshotConfiguration.widths,
+      enableJavaScript: request.body.enableJavaScript,
+      minHeight: request.body.minHeight || snapshotConfiguration['min-height'],
+    }
+
     const resources = await this.snapshotService.buildResources(
       request.body.url,
       request.body.domSnapshot,
-      request.body.enableJavaScript,
+      snapshotOptions,
     )
-
-    const snapshotConfiguration = (configuration().snapshot || {}) as SnapshotConfiguration
 
     const snapshotCreation = this.snapshotService.create(
       request.body.name,
       resources,
-      request.body.enableJavaScript,
-      request.body.widths || snapshotConfiguration.widths,
-      request.body.minHeight || snapshotConfiguration['min-height'],
+      snapshotOptions,
       request.body.clientInfo,
       request.body.environmentInfo,
     )

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -1,4 +1,5 @@
 import * as puppeteer from 'puppeteer'
+import { SnapshotOptions } from '../percy-agent-client/snapshot-options'
 import logger, {logError, profile} from '../utils/logger'
 import waitForNetworkIdle from '../utils/wait-for-network-idle'
 import PercyClientService from './percy-client-service'
@@ -38,7 +39,7 @@ export default class AssetDiscoveryService extends PercyClientService {
     profile('-> assetDiscoveryService.browser.newPage')
   }
 
-  async discoverResources(rootResourceUrl: string, domSnapshot: string, enableJavaScript = false): Promise<any[]> {
+  async discoverResources(rootResourceUrl: string, domSnapshot: string, options: SnapshotOptions): Promise<any[]> {
     profile('-> assetDiscoveryService.discoverResources')
 
     if (!this.browser || !this.page) {
@@ -52,7 +53,7 @@ export default class AssetDiscoveryService extends PercyClientService {
 
     let resources: any[] = []
 
-    await this.page.setJavaScriptEnabled(enableJavaScript)
+    await this.page.setJavaScriptEnabled(options.enableJavaScript || false)
 
     this.page.on('request', async (request) => {
       if (!this.shouldRequestResolve(request)) {

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -1,3 +1,4 @@
+import { SnapshotOptions } from '../percy-agent-client/snapshot-options'
 import {logError, profile} from '../utils/logger'
 import AssetDiscoveryService from './asset-discovery-service'
 import PercyClientService from './percy-client-service'
@@ -28,7 +29,7 @@ export default class SnapshotService extends PercyClientService {
   async buildResources(
     rootResourceUrl: string,
     domSnapshot = '',
-    enableJavaScript = false,
+    options: SnapshotOptions,
   ): Promise<any[]> {
     const rootResource = await this.percyClient.makeResource({
       resourceUrl: rootResourceUrl,
@@ -41,7 +42,7 @@ export default class SnapshotService extends PercyClientService {
     const discoveredResources = await this.assetDiscoveryService.discoverResources(
       rootResourceUrl,
       domSnapshot,
-      enableJavaScript,
+      options,
     )
     resources = resources.concat([rootResource])
     resources = resources.concat(discoveredResources)
@@ -52,14 +53,12 @@ export default class SnapshotService extends PercyClientService {
   create(
     name: string,
     resources: any[],
-    enableJavaScript = false,
-    widths: number[] | null = null,
-    minHeight: number | null = null,
+    options: SnapshotOptions = {},
     clientInfo: string | null = null,
     environmentInfo: string | null = null,
   ): Promise<any> {
     const snapshotCreationPromise: Promise<any> = this.percyClient.createSnapshot(
-      this.buildId, resources, {name, widths, enableJavaScript, minimumHeight: minHeight, clientInfo, environmentInfo},
+      this.buildId, resources, { name, ...options, minimumHeight: options.minHeight, clientInfo, environmentInfo },
     ).then(async (response: any) => {
       await this.resourceService.uploadMissingResources(response, resources)
       return response


### PR DESCRIPTION
This PR introduces no functional changes, and is only a small refactor on how we pass around things like `widths` and `enableJavaScript`.

I think this variant helps keep things a little more consistent throughout the codebase, and we'll need it in any case as part of the responsive asset work, which requires `discoverResources(...)` to be aware of the requested snapshot `widths`.