### PR TITLE
Fix how we pass parameters through to profile

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,7 +16,13 @@ export function profile(
   callback?: (err: Error, level: string, msg: string, meta: any) => void,
 ): winston.LoggerInstance | undefined {
   if (process.env.LOG_LEVEL === 'debug') {
-    return logger.profile(id, id, meta, callback)
+    // Only pass the callback through if it is defined, because the winston.Logger implementation
+    // does not behave as expected if you pass a null callback (it will ignore the meta parameter).
+    if (callback) {
+      return logger.profile(id, id, meta, callback)
+    } else {
+      return logger.profile(id, id, meta)
+    }
   }
 }
 


### PR DESCRIPTION
Because of an underlying quirk in the `winston.Logger` implementation, if we pass `null` for the callback parameter, the `meta` parameter will get ignored. This is because their code relies on the length of the argument list passed in, and even a `null` parameter counts towards the length; for details see their code in: https://github.com/winstonjs/winston/blob/2.4.4/lib/winston/logger.js#L582-L586

Passing through the `callback` only if it is defined makes it so that our `meta` parameter is treated correctly and the `meta` info is output to the log. 