### PR TITLE
Skip copying file if we seem to have already made a copy

### DIFF
--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -71,7 +71,11 @@ export default class ResponseService extends PercyClientService {
     const sha = crypto.createHash('sha256').update(buffer).digest('hex')
     const filename = path.join(this.tmpDir(), sha)
 
-    fs.writeFileSync(filename, buffer)
+    if (!fs.existsSync(filename)) {
+      fs.writeFileSync(filename, buffer)
+    } else {
+      logger.debug(`Skipping file copy (already copied): ${response.url()}`)
+    }
 
     return filename
   }


### PR DESCRIPTION
A small optimization to avoid overly taxing the hard drive and saving ourselves some work. This becomes more important with the parallel resource discovery that we're introducing in https://github.com/percy/percy-agent/pull/81, which makes it much more likely that we will try to copy something we've already copied.