### PR TITLE
Add debug logs when posting a snapshot via sdk utils fails

### DIFF
--- a/src/utils/sdk-utils.ts
+++ b/src/utils/sdk-utils.ts
@@ -23,7 +23,7 @@ export async function isAgentRunning() {
   }
 
 export async function postSnapshot(body: any) {
-    const url =`http://localhost:${Constants.PORT}${Constants.SNAPSHOT_PATH}`
+    const url = `http://localhost:${Constants.PORT}${Constants.SNAPSHOT_PATH}`
     return Axios({
       method: 'post',
       url,

--- a/src/utils/sdk-utils.ts
+++ b/src/utils/sdk-utils.ts
@@ -1,6 +1,7 @@
 import Axios from 'axios'
 import * as path from 'path'
 import Constants from '../services/constants'
+import logger from './logger'
 
 export function agentJsFilename() {
   try {
@@ -22,13 +23,18 @@ export async function isAgentRunning() {
   }
 
 export async function postSnapshot(body: any) {
+    const url =`http://localhost:${Constants.PORT}${Constants.SNAPSHOT_PATH}`
     return Axios({
       method: 'post',
-      url: `http://localhost:${Constants.PORT}${Constants.SNAPSHOT_PATH}`,
+      url,
       data: body,
     } as any).then(() => {
       return true
     }).catch((error) => {
+      // This code runs in the context of the SDK, so the SDK needs to have LOG_LEVEL=debug
+      // enabled for these logs to appear.
+      logger.debug(`Error posting snapshot to ${url} with body: ${body}`)
+      logger.debug(error)
       return false
     })
   }


### PR DESCRIPTION
The one debatable choice in this change is that I'm using the logger we use in `@percy/agent` to emit logs that will come from the SDK process. I think this is preferable to changing the code to pass through the error and then updating all the SDKs to log the error, plus putting it here makes it possible to use our nice `logger`.

wdyt @Robdel12 @djones ?