### PR TITLE
Serialize textareas for snapshots

### DIFF
--- a/src/percy-agent-client/percy-agent.ts
+++ b/src/percy-agent-client/percy-agent.ts
@@ -96,7 +96,8 @@ export default class PercyAgent {
         }
         break
       case 'textarea':
-        elem.setAttribute('text', elem.value)
+        // setting text or value does not work but innerText does
+        elem.innerText = elem.value
       default:
         elem.setAttribute('value', elem.value)
       }

--- a/src/percy-agent-client/percy-agent.ts
+++ b/src/percy-agent-client/percy-agent.ts
@@ -84,10 +84,10 @@ export default class PercyAgent {
 
   private serializeInputElements(doc: HTMLDocument): HTMLDocument {
     const domClone = doc.documentElement
-    const inputNodes = domClone.getElementsByTagName('input')
-    const inputElements = Array.prototype.slice.call(inputNodes) as HTMLInputElement[]
+    const formNodes = domClone.querySelectorAll('input, textarea')
+    const formElements = Array.prototype.slice.call(formNodes)
 
-    inputElements.forEach((elem: HTMLInputElement) => {
+    formElements.forEach((elem: HTMLInputElement) => {
       switch (elem.type) {
       case 'checkbox':
       case 'radio':
@@ -95,6 +95,8 @@ export default class PercyAgent {
           elem.setAttribute('checked', '')
         }
         break
+      case 'textarea':
+        elem.setAttribute('text', elem.value)
       default:
         elem.setAttribute('value', elem.value)
       }

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -117,6 +117,13 @@ describe('Integration test', () => {
         expect(domSnapshot).to.contain('type="checkbox" checked')
         expect(domSnapshot).to.contain('type="radio" checked')
       })
+
+      it('serializes textarea elements', async () => {
+        await page.type('#testTextarea', 'test textarea value')
+
+        const domSnapshot = await snapshot(page, 'Serialize textarea elements')
+        expect(domSnapshot).to.contain('test textarea value')
+      })
     })
   })
 })

--- a/test/integration/testcases/stabilize-dom.html
+++ b/test/integration/testcases/stabilize-dom.html
@@ -12,6 +12,7 @@
       <input id="testInputText" />
       <input id="testCheckbox" type="checkbox"/>
       <input id="testRadioButton" type="radio"/>
+      <textarea id="testTextarea" name="testTextArea" rows="10"></textarea>
     </p>
     <!-- End of test elements for input element serialization. -->
 


### PR DESCRIPTION
## What is this?

Previously we were only serializing input elements. This adds textareas to that list. They're a bit of a special element. I couldn't get it to work locally when setting the `value`, `text`, or anything else besides `innerText`. Which seems fine. 

[I splunked through how jQuery does it and they're setting the `textContent`](https://github.com/jquery/jquery/blob/master/src/manipulation.js#L334). I created a little jsbin to illustrate the differences: https://jsbin.com/hiquvuzele/1/edit?html,js,output
I have no issues changing `innerText` to `textContent` if that's something we want to do. 