### PR TITLE
Add width of snapshot to resource logging

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -153,7 +153,7 @@ export default class AssetDiscoveryService extends PercyClientService {
     page.on('response', async (response) => {
       // Parallelize the work in processResponse as much as possible, but make sure to
       // wait for it to complete before returning from the asset discovery phase.
-      const promise = this.responseService.processResponse(rootResourceUrl, response)
+      const promise = this.responseService.processResponse(rootResourceUrl, response, width)
       promise.catch(logError)
       maybeResourcePromises.push(promise)
     })

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -19,8 +19,8 @@ export default class ResponseService extends PercyClientService {
     this.resourceService = new ResourceService(buildId)
   }
 
-  async processResponse(rootResourceUrl: string, response: puppeteer.Response): Promise<any | null> {
-    logger.debug(`processing response: ${response.url()}`)
+  async processResponse(rootResourceUrl: string, response: puppeteer.Response, width: number): Promise<any | null> {
+    logger.debug(`processing response: ${response.url()} for width: ${width}`)
     const url = this.parseRequestPath(response.url())
 
     // skip responses already processed
@@ -39,19 +39,19 @@ export default class ResponseService extends PercyClientService {
 
     if (!this.ALLOWED_RESPONSE_STATUSES.includes(response.status())) {
       // Only allow 2XX responses:
-      logger.debug(`Skipping [disallowed_response_status_${response.status()}]: ${response.url()}`)
+      logger.debug(`Skipping [disallowed_response_status_${response.status()}] [${width} px]: ${response.url()}`)
       return
     }
 
     if (!request.url().startsWith(rootUrl)) {
       // Disallow remote resource requests.
-      logger.debug(`Skipping [is_remote_resource]: ${request.url()}`)
+      logger.debug(`Skipping [is_remote_resource] [${width} px]: ${request.url()}`)
       return
     }
 
     if (!response.url().startsWith(rootUrl)) {
       // Disallow remote redirects.
-      logger.debug(`Skipping [is_remote_redirect]: ${response.url()}`)
+      logger.debug(`Skipping [is_remote_redirect] [${width} px]: ${response.url()}`)
       return
     }
 


### PR DESCRIPTION
As suggested by @Robdel12 , this makes the logs when snapshotting multiple widths in parallel a little bit more useful. Right now they look like:
```
[percy] processing response: https://10.43.238.110:3000/innovate-blog-staging
[percy] Skipping [is_root_resource]: https://10.43.238.110:3000/innovate-blog-staging
[percy] processing response: https://10.43.238.110:3000/innovate-blog-staging
[percy] Skipping [is_root_resource]: https://10.43.238.110:3000/innovate-blog-staging
[percy] processing response: https://10.43.238.110:3000/innovate-blog-staging
[percy] Skipping [is_root_resource]: https://10.43.238.110:3000/innovate-blog-staging
```

There is, of course, the somewhat unfortunate thing of passing around the width _just_ for logging. But worth it for better logging, I think.