### PR TITLE
Add support for 10mb+ DOM snapshots

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -4,4 +4,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 5000
+--timeout 20000


### PR DESCRIPTION
So far, we have a failing test case.