### PR TITLE
Carefully undo our serialized CSSOM from the customer DOM. Add tests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -967,7 +967,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1714,7 +1714,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -2220,7 +2220,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4139,7 +4139,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -4946,7 +4946,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "optional": true,
           "requires": {
@@ -4968,7 +4968,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -5375,7 +5375,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -5450,7 +5450,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -6249,7 +6249,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -7584,7 +7584,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/src/percy-agent-client/percy-agent.ts
+++ b/src/percy-agent-client/percy-agent.ts
@@ -1,7 +1,7 @@
 import Constants from '../services/constants'
 import {ClientOptions} from './client-options'
 import {PercyAgentClient} from './percy-agent-client'
-import {serializeCssOm} from './serialize-cssom'
+import {cleanSerializedCssOm, serializeCssOm} from './serialize-cssom'
 import {SnapshotOptions} from './snapshot-options'
 
 export default class PercyAgent {
@@ -68,7 +68,15 @@ export default class PercyAgent {
       domClone = this.domTransformation(domClone)
     }
 
-    return doctype + domClone.outerHTML
+    const snapshotString = doctype + domClone.outerHTML
+
+    // Remove all the additions we've made to the original DOM.
+    // Ideally we would make a deep clone of the original DOM at the start of this
+    // method, and operate on that, but this turns out to be hard to do while
+    // retaining CSS OM and input element state. Instead, we carefully remove what we added.
+    cleanSerializedCssOm(documentObject)
+
+    return snapshotString
   }
 
   private getDoctype(documentObject: Document): string {

--- a/src/percy-agent-client/serialize-cssom.ts
+++ b/src/percy-agent-client/serialize-cssom.ts
@@ -32,8 +32,9 @@ export function serializeCssOm(document: HTMLDocument) {
 
 export function cleanSerializedCssOm(document: HTMLDocument) {
   // IMPORTANT: querySelectorAll(...) will not always work. In particular, in certain
-  // cases with malformed HTML (e.g. a <style> tag instead of another one), some of
-  // the elements we are looking for will not be returned.
+  // cases with malformed HTML (e.g. a <style> tag inside of another one), some of
+  // the elements we are looking for will not be returned. In that case, we will
+  // leave traces of ourselves in the underlying DOM.
   const nodes = document.querySelectorAll(`[${DATA_ATTRIBUTE}]`)
   Array.from(nodes).forEach((node: Element) => {
     node.removeAttribute(DATA_ATTRIBUTE)

--- a/test/helpers/html-string.ts
+++ b/test/helpers/html-string.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns the HTML of the given Document as a string, with the HTML corresponding to
+ * the given selector removed. Does all this without modifying the actual Document.
+ */
+export function htmlWithoutSelector(doc: Document, selector: string): string {
+  const fullHTML = document.documentElement.outerHTML
+  const selectedElement = document.querySelector(selector)
+  if (selectedElement === null) {
+    throw new Error(`Could not find ${selector} in document.`)
+  }
+
+  const selectorHTML = selectedElement.outerHTML
+  return fullHTML.replace(selectorHTML, '')
+}

--- a/test/percy-agent-client/percy-agent.test.ts
+++ b/test/percy-agent-client/percy-agent.test.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import * as sinon from 'sinon'
 import PercyAgent from '../../src/percy-agent-client/percy-agent'
 import Constants from '../../src/services/constants'
+import { htmlWithoutSelector } from '../helpers/html-string'
 
 describe('PercyAgent', () => {
   let requests: sinon.SinonFakeXMLHttpRequest[] = []
@@ -92,14 +93,17 @@ describe('PercyAgent', () => {
     })
 
     it('does not alter the DOM being snapshotted', () => {
-      const originalHTML = document.documentElement.outerHTML
+      const originalHTML = htmlWithoutSelector(document, '#mocha')
 
-      const firstDOMSnapshot = subject.snapshot('a snapshot')
+      subject.snapshot('a snapshot')
 
-      const postSnapshotHTML = document.documentElement.outerHTML
+      const postSnapshotHTML = htmlWithoutSelector(document, '#mocha')
       expect(postSnapshotHTML).to.eq(originalHTML)
       expect(postSnapshotHTML).to.not.contain('data-percy')
+    })
 
+    it('multiple snapshots produce the same result', () => {
+      const firstDOMSnapshot = subject.snapshot('a snapshot')
       const secondDOMSnapshot = subject.snapshot('a second snapshot')
       expect(secondDOMSnapshot).to.eq(firstDOMSnapshot)
     })

--- a/test/percy-agent-client/percy-agent.test.ts
+++ b/test/percy-agent-client/percy-agent.test.ts
@@ -90,5 +90,18 @@ describe('PercyAgent', () => {
 
       expect(requestBody.domSnapshot).to.contain('checked')
     })
+
+    it('does not alter the DOM being snapshotted', () => {
+      const originalHTML = document.documentElement.outerHTML
+
+      const firstDOMSnapshot = subject.snapshot('a snapshot')
+
+      const postSnapshotHTML = document.documentElement.outerHTML
+      expect(postSnapshotHTML).to.eq(originalHTML)
+      expect(postSnapshotHTML).to.not.contain('data-percy')
+
+      const secondDOMSnapshot = subject.snapshot('a second snapshot')
+      expect(secondDOMSnapshot).to.eq(firstDOMSnapshot)
+    })
   })
 })

--- a/test/percy-agent-client/serialize-cssom.test.ts
+++ b/test/percy-agent-client/serialize-cssom.test.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai'
 import * as sinon from 'sinon'
 import PercyAgent from '../../src/percy-agent-client/percy-agent'
 import Constants from '../../src/services/constants'
+import { htmlWithoutSelector } from '../helpers/html-string'
 
 describe('serializeCssOm', () => {
   const subject: PercyAgent = new PercyAgent({ handleAgentCommunication: false })
@@ -16,6 +17,15 @@ describe('serializeCssOm', () => {
 
       const parsedDoc = (new DOMParser()).parseFromString(domSnapshot, 'text/html')
       expect(parsedDoc.getElementById('jsStyled')!.style.background).to.contain('red')
+    })
+
+    it('cleans up after itself', () => {
+      subject.snapshot('test snapshot')
+
+      const postSnapshotHTML = htmlWithoutSelector(document, '#mocha')
+
+      expect(postSnapshotHTML).to.not.contain('data-percy-cssom-serialized')
+      expect(postSnapshotHTML).to.not.contain('Start of Percy serialized CSSOM')
     })
   })
 })


### PR DESCRIPTION
This solution works in the general case, and this PR adds a test making sure that the behavior doesn't regress.

It is important to note, however, that in cases of malformed or otherwise degenerate underlying DOM, the clean up might not work perfectly, leaving behind pieces of serialized CSS.

I don't love having to do things this way -- it would be much cleaner to make a deep copy of the DOM and operate always on that. On the positive side, this implementation feels robust and understandable enough that it should be fairly maintainable.

Thoughts?