### PR TITLE
Allow assets from additional domains to be processed

### DIFF
--- a/src/services/agent-options.ts
+++ b/src/services/agent-options.ts
@@ -1,4 +1,5 @@
 export interface AgentOptions {
   port?: number,
-  networkIdleTimeout?: number
+  networkIdleTimeout?: number,
+  assetDomains?: string
 }

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -42,7 +42,10 @@ export default class AgentService {
 
     if (this.buildId !== null) {
       this.server = this.app.listen(options.port)
-      this.snapshotService = new SnapshotService(this.buildId, {networkIdleTimeout: options.networkIdleTimeout})
+      this.snapshotService = new SnapshotService(this.buildId, {
+        networkIdleTimeout: options.networkIdleTimeout,
+        assetDomains: options.assetDomains,
+      })
       await this.snapshotService.assetDiscoveryService.setup()
       return
     }

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -6,7 +6,8 @@ import PercyClientService from './percy-client-service'
 import ResponseService from './response-service'
 
 interface AssetDiscoveryOptions {
-  networkIdleTimeout?: number
+  networkIdleTimeout?: number,
+  assetDomains?: string
 }
 
 export default class AssetDiscoveryService extends PercyClientService {
@@ -26,7 +27,7 @@ export default class AssetDiscoveryService extends PercyClientService {
 
   constructor(buildId: number, options: AssetDiscoveryOptions = {}) {
     super()
-    this.responseService = new ResponseService(buildId)
+    this.responseService = new ResponseService(buildId, options.assetDomains)
     this.networkIdleTimeout = options.networkIdleTimeout || this.DEFAULT_NETWORK_IDLE_TIMEOUT
     this.browser = null
     this.pages = null

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -5,7 +5,8 @@ import PercyClientService from './percy-client-service'
 import ResourceService from './resource-service'
 
 interface SnapshotServiceOptions {
-  networkIdleTimeout?: number
+  networkIdleTimeout?: number,
+  assetDomains?: string
 }
 
 export default class SnapshotService extends PercyClientService {
@@ -20,7 +21,7 @@ export default class SnapshotService extends PercyClientService {
     this.buildId = buildId
     this.assetDiscoveryService = new AssetDiscoveryService(
       buildId,
-      {networkIdleTimeout: options.networkIdleTimeout},
+      {networkIdleTimeout: options.networkIdleTimeout, assetDomains: options.assetDomains},
     )
 
     this.resourceService = new ResourceService(buildId)

--- a/test/commands/start.test.ts
+++ b/test/commands/start.test.ts
@@ -67,6 +67,26 @@ describe('Start', () => {
       )
     })
 
+    it('starts percy agent in detached mode with asset domains', async () => {
+      const processService = ProcessServiceStub()
+
+      const assetDomains = 'http://cdn1.example.com,http://cdn2.example.com'
+      const options = ['--detached', '--asset-domains', assetDomains]
+
+      await captureStdOut(async () => {
+        await Start.run(options)
+      })
+
+      expect(processService.runDetached).to.calledWithMatch(
+        [
+          path.resolve(`${__dirname}/../../bin/run`), 'start',
+          '-p', String(Constants.PORT),
+          '-t', '50',
+          '-a', assetDomains,
+        ],
+      )
+    })
+
     it('starts percy agent on a specific port', async () => {
       const agentServiceStub = AgentServiceStub()
 
@@ -78,6 +98,24 @@ describe('Start', () => {
       })
 
       expect(agentServiceStub.start).to.calledWithMatch({port: +port, networkIdleTimeout: 50})
+      expect(stdout).to.contain('[percy] percy has started.')
+    })
+
+    it('starts percy agent with additional asset domains', async () => {
+      const agentServiceStub = AgentServiceStub()
+
+      const assetDomains = 'http://cdn1.example.com,http://cdn2.example.com'
+      const options = ['--asset-domains', assetDomains]
+
+      const stdout = await captureStdOut(async () => {
+        await Start.run(options)
+      })
+
+      expect(agentServiceStub.start).to.calledWithMatch({
+        port: Constants.PORT,
+        networkIdleTimeout: 50,
+        assetDomains,
+      })
       expect(stdout).to.contain('[percy] percy has started.')
     })
 


### PR DESCRIPTION
I recently messaged Percy.io via Intercom about an issue we are having with images / logos not appearing in our screenshots.

Our assets are served up from a separate domain, which percy is set up to ignore to reduce the overall number of assets that have to be processed. Unfortunately for us, our testing occurs behind a corporate VPN so those assets are not available to percy.

This PR introduces a new `-a` / `--asset-domains` flag, which takes in a comma separated list of asset domains that should be processed in addition to the root domain.

Please let me know if this is something you are interested in or if you need any additional information / work from me.

Thanks for making an awesome service!