### PR TITLE
Clean up serialized inputs after snapshotting

### DIFF
--- a/src/percy-agent-client/serialize-input.ts
+++ b/src/percy-agent-client/serialize-input.ts
@@ -1,0 +1,51 @@
+const DATA_ATTRIBUTE_CHECKED = 'data-percy-input-serialized-checked'
+const DATA_ATTRIBUTE_TEXTAREA_INNERTEXT = 'data-percy-input-serialized-textarea-innertext'
+const DATA_ATTRIBUTE_VALUE = 'data-percy-input-serialized-value'
+
+export function serializeInputElements(doc: HTMLDocument): HTMLDocument {
+  const domClone = doc.documentElement
+  const formNodes = domClone.querySelectorAll('input, textarea')
+  const formElements = Array.prototype.slice.call(formNodes)
+
+  formElements.forEach((elem: HTMLInputElement) => {
+    switch (elem.type) {
+    case 'checkbox':
+    case 'radio':
+      if (elem.checked && !elem.hasAttribute('checked')) {
+        elem.setAttribute('checked', '')
+        elem.setAttribute(DATA_ATTRIBUTE_CHECKED, '')
+      }
+      break
+    case 'textarea':
+      // setting text or value does not work but innerText does
+      if (elem.innerText !== elem.value) {
+        elem.setAttribute(DATA_ATTRIBUTE_TEXTAREA_INNERTEXT, elem.innerText)
+        elem.innerText = elem.value
+      }
+    default:
+      if (!elem.getAttribute('value')) {
+        elem.setAttribute(DATA_ATTRIBUTE_VALUE, '')
+        elem.setAttribute('value', elem.value)
+      }
+    }
+  })
+
+  return doc
+}
+
+export function cleanSerializedInputElements(doc: HTMLDocument) {
+  doc.querySelectorAll(`[${DATA_ATTRIBUTE_CHECKED}]`).forEach((el: Element) => {
+    el.removeAttribute('checked')
+    el.removeAttribute(DATA_ATTRIBUTE_CHECKED)
+  })
+  doc.querySelectorAll(`[${DATA_ATTRIBUTE_TEXTAREA_INNERTEXT}]`).forEach((el: Element)  => {
+    const originalInnerText: string = el.getAttribute(DATA_ATTRIBUTE_TEXTAREA_INNERTEXT) || ''
+    const textArea = el as HTMLTextAreaElement
+    textArea.innerText = originalInnerText
+    el.removeAttribute(DATA_ATTRIBUTE_TEXTAREA_INNERTEXT)
+  })
+  doc.querySelectorAll(`[${DATA_ATTRIBUTE_VALUE}]`).forEach((el: Element) => {
+    el.removeAttribute('value')
+    el.removeAttribute(DATA_ATTRIBUTE_VALUE)
+  })
+}

--- a/test/percy-agent-client/percy-agent.test.ts
+++ b/test/percy-agent-client/percy-agent.test.ts
@@ -59,39 +59,6 @@ describe('PercyAgent', () => {
       expect(requestBody.minHeight).to.equal(512)
     })
 
-    it('serializes text input elements', () => {
-      const inputName = document.getElementById('testInputText') as HTMLInputElement
-      inputName.value = 'test input value'
-      subject.snapshot('test snapshot')
-
-      const request = requests[0]
-      const requestBody = JSON.parse(request.requestBody)
-
-      expect(requestBody.domSnapshot).to.contain('test input value')
-    })
-
-    it('serializes checkbox elements', () => {
-      const inputName = document.getElementById('testCheckbox') as HTMLInputElement
-      inputName.checked = true
-
-      subject.snapshot('test snapshot')
-      const request = requests[0]
-      const requestBody = JSON.parse(request.requestBody)
-
-      expect(requestBody.domSnapshot).to.contain('checked')
-    })
-
-    it('serializes radio button elements', () => {
-      const inputName = document.getElementById('testRadioButton') as HTMLInputElement
-      inputName.checked = true
-
-      subject.snapshot('test snapshot')
-      const request = requests[0]
-      const requestBody = JSON.parse(request.requestBody)
-
-      expect(requestBody.domSnapshot).to.contain('checked')
-    })
-
     it('does not alter the DOM being snapshotted', () => {
       const originalHTML = htmlWithoutSelector(document, '#mocha')
 

--- a/test/percy-agent-client/serialize-input.test.ts
+++ b/test/percy-agent-client/serialize-input.test.ts
@@ -1,0 +1,47 @@
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+import PercyAgent from '../../src/percy-agent-client/percy-agent'
+import Constants from '../../src/services/constants'
+import { htmlWithoutSelector } from '../helpers/html-string'
+
+describe('serializeInputElements', () => {
+  const subject: PercyAgent = new PercyAgent({ handleAgentCommunication: false })
+
+  it('serializes text input elements', () => {
+    const inputName = document.getElementById('testInputText') as HTMLInputElement
+    inputName.value = 'test input value'
+    const domSnapshot = subject.snapshot('test snapshot')
+
+    expect(domSnapshot).to.contain('test input value')
+  })
+
+  it('serializes checkbox elements', () => {
+    const inputName = document.getElementById('testCheckbox') as HTMLInputElement
+    inputName.checked = true
+
+    const domSnapshot = subject.snapshot('test snapshot')
+
+    expect(domSnapshot).to.contain('checked')
+  })
+
+  it('serializes radio button elements', () => {
+    const inputName = document.getElementById('testRadioButton') as HTMLInputElement
+    inputName.checked = true
+
+    const domSnapshot = subject.snapshot('test snapshot')
+
+    expect(domSnapshot).to.contain('checked')
+  })
+
+  it('cleans up after itself', () => {
+    const preSnapshotHTML = htmlWithoutSelector(document, '#mocha')
+
+    subject.snapshot('test snapshot')
+
+    const postSnapshotHTML = htmlWithoutSelector(document, '#mocha')
+
+    expect(postSnapshotHTML).to.eq(preSnapshotHTML)
+    expect(postSnapshotHTML).to.not.contain('data-percy-input-serialized')
+    expect(postSnapshotHTML).to.not.contain('checked')
+  })
+})


### PR DESCRIPTION
I've also made the logic of the serialization a little bit more conservative, doing the serialization only when it seems to be necessary. The drawback of that is that it makes the implementation a little bit less obvious (and thus more likely to contain a bug).

Finally, this change also moves input serialization into its own file (and associated test), similar to the structure we have for the CSSOM serialization code.

(This PR is the follow-up I promised in https://github.com/percy/percy-agent/pull/109)