### PR TITLE
Add browser field so bundlers don't bundle node files

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   ],
   "license": "MIT",
   "main": "dist/index.js",
+  "browser": "dist/public/percy-agent.js",
   "oclif": {
     "commands": "./dist/commands",
     "bin": "percy",


### PR DESCRIPTION
## What is this?

This adds a `browser` field to the agent `package.json` so bundlers like webpack, parcel, rollup, etc won't bundle our node process code with the code we inject into the browser. This will solve this issue: https://github.com/percy/percy-cypress/issues/58 so folks no longer need to modify their webpack config due to errors originating in agent. 