### PR TITLE
feat: Add `healthcheck` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - restore_cache: &restore_cache
           keys:
-            - v1-yarn-{{checksum ".circleci/config.yml"}}-{{ checksum "yarn.lock"}}
+            - v1-yarn-{{checksum ".circleci/config.yml"}}-{{ checksum "package-lock.json"}}
             - v1-yarn-{{checksum ".circleci/config.yml"}}
       - run: .circleci/greenkeeper
       - run: yarn add -D nyc@11 @oclif/nyc-config@1 mocha-junit-reporter@1

--- a/src/commands/health-check.ts
+++ b/src/commands/health-check.ts
@@ -1,11 +1,10 @@
-import {flags} from '@oclif/command'
+import {Command, flags} from '@oclif/command'
 import * as colors from 'colors'
 import Constants from '../services/constants'
 import healthCheck from '../utils/health-checker'
-import PercyCommand from './percy-command'
 
-export default class HealthCheck extends PercyCommand {
-  static description = 'Determins if the Percy Agent process is currently running'
+export default class HealthCheck extends Command {
+  static description = 'Determines if the Percy Agent process is currently running'
   static hidden = true
 
   static flags = {
@@ -22,11 +21,6 @@ export default class HealthCheck extends PercyCommand {
   ]
 
   async run() {
-    await super.run()
-
-    // If Percy is disabled or is missing a token, gracefully exit here
-    if (!this.percyWillRun()) { this.exit(0) }
-
     const {flags} = this.parse(HealthCheck)
     const port = flags.port as number
 

--- a/src/commands/health-check.ts
+++ b/src/commands/health-check.ts
@@ -1,0 +1,37 @@
+import {flags} from '@oclif/command'
+import * as colors from 'colors'
+import Constants from '../services/constants'
+import healthCheck from '../utils/health-checker'
+import PercyCommand from './percy-command'
+
+export default class HealthCheck extends PercyCommand {
+  static description = 'Determins if the Percy Agent process is currently running'
+  static hidden = true
+
+  static flags = {
+    port: flags.integer({
+      char: 'p',
+      default: Constants.PORT,
+      description: 'port',
+    }),
+  }
+
+  static examples = [
+    '$ percy healthcheck',
+    '$ percy healthcheck --port 6884',
+  ]
+
+  async run() {
+    await super.run()
+
+    // If Percy is disabled or is missing a token, gracefully exit here
+    if (!this.percyWillRun()) { this.exit(0) }
+
+    const {flags} = this.parse(HealthCheck)
+    const port = flags.port as number
+
+    await healthCheck(port, {
+      shouldRetry: () => false,
+    })
+  }
+}

--- a/src/utils/health-checker.ts
+++ b/src/utils/health-checker.ts
@@ -2,13 +2,14 @@ import Axios from 'axios'
 import * as retryAxios from 'retry-axios'
 import logger from './logger'
 
-async function healthCheck(port: number) {
+async function healthCheck(port: number, retryOptions?: object) {
   const healthcheckUrl = `http://localhost:${port}/percy/healthcheck`
 
   const retryConfig = {
     retry: 5, // with exponential back off
     retryDelay: 500,
     shouldRetry: () => true,
+    ...retryOptions,
   }
 
   const interceptorId = retryAxios.attach()

--- a/test/commands/health-check.test.ts
+++ b/test/commands/health-check.test.ts
@@ -1,8 +1,8 @@
 import * as chai from 'chai'
-import * as nock from 'nock'
 import {describe} from 'mocha'
+import * as nock from 'nock'
 import HealthCheck from '../../src/commands/health-check'
-import {captureStdOut, captureStdErr} from '../helpers/stdout'
+import {captureStdErr, captureStdOut} from '../helpers/stdout'
 
 const expect = chai.expect
 
@@ -17,7 +17,7 @@ describe('Health check', () => {
     })
 
     it('messages that agent is ready', async () => {
-      const stdout = await captureStdOut(async () => await HealthCheck.run([]))
+      const stdout = await captureStdOut(async () => HealthCheck.run([]))
 
       expect(stdout).to.contain('[percy] percy is ready.')
     })
@@ -33,7 +33,7 @@ describe('Health check', () => {
     })
 
     it('messages that agent is not ready', async () => {
-      const errorStdout = await captureStdErr(async () => await HealthCheck.run([]))
+      const errorStdout = await captureStdErr(async () => HealthCheck.run([]))
 
       expect(errorStdout).to
         .contain('[percy] Failed to establish a connection with http://localhost:5338/percy/healthcheck')
@@ -42,7 +42,7 @@ describe('Health check', () => {
     it('properly passes the port', async () => {
       const port = '5899'
       const errorStdout = await captureStdErr(async () =>
-        await HealthCheck.run(['--port', port])
+        HealthCheck.run(['--port', port]),
       )
 
       expect(errorStdout).to

--- a/test/commands/health-check.test.ts
+++ b/test/commands/health-check.test.ts
@@ -1,0 +1,52 @@
+import * as chai from 'chai'
+import * as nock from 'nock'
+import {describe} from 'mocha'
+import HealthCheck from '../../src/commands/health-check'
+import {captureStdOut, captureStdErr} from '../helpers/stdout'
+
+const expect = chai.expect
+
+describe('Health check', () => {
+  describe('when agent is running', () => {
+    beforeEach(() => {
+      nock(/localhost/).get('/percy/healthcheck').reply(200)
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    it('messages that agent is ready', async () => {
+      const stdout = await captureStdOut(async () => await HealthCheck.run([]))
+
+      expect(stdout).to.contain('[percy] percy is ready.')
+    })
+  })
+
+  describe('when agent is not running', () => {
+    beforeEach(() => {
+      nock(/localhost/).get('/percy/healthcheck').reply(500)
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    it('messages that agent is not ready', async () => {
+      const errorStdout = await captureStdErr(async () => await HealthCheck.run([]))
+
+      expect(errorStdout).to
+        .contain('[percy] Failed to establish a connection with http://localhost:5338/percy/healthcheck')
+    })
+
+    it('properly passes the port', async () => {
+      const port = '5899'
+      const errorStdout = await captureStdErr(async () =>
+        await HealthCheck.run(['--port', port])
+      )
+
+      expect(errorStdout).to
+        .contain('[percy] Failed to establish a connection with http://localhost:5899/percy/healthcheck')
+    })
+  })
+})


### PR DESCRIPTION
## What is this?

In some instances it's helpful to have a CLI command that runs a check to make sure the Percy process is running. This will be especially helpful in the Cypress SDK where we're having struggles with providing a nice way to run a CLI command with the SDK:

- https://github.com/percy/percy-cypress/pull/67
- https://github.com/percy/percy-cypress/pull/69
- https://github.com/percy/percy-cypress/pull/72

## Usage

`$ percy health-check` or `$ percy health-check -p 5502`