### PR TITLE
fix: Revert & remove `browser` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   ],
   "license": "MIT",
   "main": "dist/index.js",
-  "browser": "dist/public/percy-agent.js",
   "oclif": {
     "commands": "./dist/commands",
     "bin": "percy",


### PR DESCRIPTION
## What is this?

Looks like we need to also introduce rollup to bunndle all of the files together into a single file when we introduce the `browser` field. Otherwise bundlers are going to fall over at the bad `require` file paths. 