### PR TITLE
fix: avoid node-based sdk-utils in default export for package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 import PercyAgent from './percy-agent-client/percy-agent'
-export * from './utils/sdk-utils'
 export default PercyAgent


### PR DESCRIPTION
@percy/agent is sometimes imported like this in our SDKs:

```javascript
import PercyAgent from '@percy/agent'
```

At which point the default export is imported. This export is intended to run in a browser and everything in the `src/percy-agent-client` directory is built to expect this.

As we've built out our SDKs we found that @percy/agent is also quite useful for centralizing SDK utility functions. We previously had been distributing these util functions through the default export, so you can go:

```javascript
import { agentJsFilename, isAgentRunning, postSnapshot } from '@percy/agent'
```

The problem with that is the util code would import other libraries, such as Winston, which are entirely designed to run on Node and not in a browser.

This PR simply removes the node-specific code from our default export, but as a result we've had to update our SDKs to reach inside @percy/agent and require these utils instead.

Those PRs are here:

* https://github.com/percy/percy-protractor/pull/36
* https://github.com/percy/percy-webdriverio/pull/73
* https://github.com/percy/percy-nightwatch/pull/38
* https://github.com/percy/percy-puppeteer/pull/75
* https://github.com/percy/percy-nightmare/pull/53

Related issue:

* https://github.com/percy/percy-cypress/issues/58