### PR TITLE
fix: Build `PercyAgent` code that's inject in browser as iife

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   output: {
     name: "PercyAgent",
     file: "dist/public/percy-agent.js",
-    format: "umd"
+    format: "iife"
   },
   plugins: [
     // Allows node_modules resolution


### PR DESCRIPTION
## What is this?

We rely on the agent code we inject into the browser to be globally available on the window. There's no reason we need to distribute the code we inject into the browser as a universal module.

There are some cases where the site we inject the current agent code into that defines one of these modules (could be cjs, amd, or even the es6 module format). When that case happens it breaks out SDKs because `PercyAgent` is not defined.

This commit changes the build to output an immediately invoked function, which will always expose agent as a global.