### PR TITLE
fix: Expose `PercyAgent` as a global always

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,9 @@ export default {
   output: {
     name: "PercyAgent",
     file: "dist/public/percy-agent.js",
-    format: "umd"
+    format: "iife",
+    // a must to add `PercyAgent` to the global namespace
+    extend: true
   },
   plugins: [
     // Allows node_modules resolution


### PR DESCRIPTION
## What is this? 

Second time is the charm right? Setting `extend: true` in the rollup config allows
the bundler to extend the global namespace (window).

So, the output now looks like `this.PercyAgent = ` (where `this` is the
window object)

I cut a beta release of this and tested it on the various SDKs (btw, we need a better process for this):
- https://github.com/percy/percy-cypress/compare/rd/agent-beta-4.4
- https://github.com/percy/percy-puppeteer/compare/rd/agent-beta-4.4
- https://github.com/percy/percy-nightwatch/compare/rd/agent-beta-4.4
- https://github.com/percy/percy-webdriverio/compare/rd/agent-beta-4.4
- https://github.com/percy/percy-nightmare/compare/rd/agent-beta-4.4
- https://github.com/percy/percy-protractor/compare/rd/agent-beta-4.4
- https://github.com/percy/percy-capybara/compare/rd/agent-beta-4.4

This one should do the trick 👍 