### PR TITLE
chore: Bring back commented out tests (due to `http-server`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3508,6 +3508,12 @@
         "vary": "^1"
       }
     },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
@@ -3925,6 +3931,32 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecstatic": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
+      "dev": true,
+      "requires": {
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.1.0",
+        "url-join": "^2.0.5"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -5785,6 +5817,12 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5883,6 +5921,30 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "http-server": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
+      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3",
+        "corser": "~2.0.0",
+        "ecstatic": "^3.0.0",
+        "http-proxy": "^1.8.1",
+        "opener": "~1.4.0",
+        "optimist": "0.6.x",
+        "portfinder": "^1.0.13",
+        "union": "~0.4.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
       }
@@ -11021,6 +11083,12 @@
         "wrappy": "1"
       }
     },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -11413,6 +11481,40 @@
       "dev": true,
       "requires": {
         "semver-compare": "^1.0.0"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+      "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "posix-character-classes": {
@@ -13923,6 +14025,23 @@
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
       "dev": true
     },
+    "union": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
+      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+      "dev": true,
+      "requires": {
+        "qs": "~2.3.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        }
+      }
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -14086,6 +14205,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "dev": true
     },
     "url-parse-lax": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chai": "^4.1.2",
     "chai-http": "^4.0.0",
     "eslint-config-oclif": "^3.0.0",
+    "http-server": "^0.11.1",
     "husky": "^1.0.0-rc.13",
     "mocha": "^6.1.3",
     "nock": "^10.0.6",

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import { Server } from 'http'
-// import * as httpServer from 'http-server'
+import * as httpServer from 'http-server'
 import { describe } from 'mocha'
 import * as puppeteer from 'puppeteer'
 import { agentJsFilename } from '../../src/utils/sdk-utils'
@@ -69,64 +69,65 @@ describe('Integration test', () => {
     })
 
   })
-  // describe.skip('on local test cases', () => {
-  //   const testCaseDir = `${__dirname}/testcases`
-  //   const PORT = 8000
-  //   let server: Server
 
-  //   before(() => {
-  //     server = httpServer.createServer({root: testCaseDir}) as Server
-  //     server.listen(PORT)
-  //   })
+  describe('on local test cases', () => {
+    const testCaseDir = `${__dirname}/testcases`
+    const PORT = 8000
+    let server: Server
 
-  //   after(() => {
-  //     server.close()
-  //   })
+    before(() => {
+      server = httpServer.createServer({root: testCaseDir}) as Server
+      server.listen(PORT)
+    })
 
-  //   it('snapshots all test cases', async () => {
-  //     const testFiles = fs.readdirSync(testCaseDir).filter((fn) => fn.endsWith('.html'))
-  //     for (const fname of testFiles) {
-  //       await page.goto(`http://localhost:${PORT}/${fname}`)
-  //       const domSnapshot = await snapshot(page, `Test case: ${fname}`)
-  //     }
-  //   })
+    after(() => {
+      server.close()
+    })
 
-  //   describe('stabilizes DOM', () => {
-  //     before(async () => {
-  //       await page.goto(`http://localhost:${PORT}/stabilize-dom.html`)
-  //     })
+    it('snapshots all test cases', async () => {
+      const testFiles = fs.readdirSync(testCaseDir).filter((fn) => fn.endsWith('.html'))
+      for (const fname of testFiles) {
+        await page.goto(`http://localhost:${PORT}/${fname}`)
+        const domSnapshot = await snapshot(page, `Test case: ${fname}`)
+      }
+    })
 
-  //     it('serializes input elements', async () => {
-  //       await page.type('#testInputText', 'test input value')
-  //       await page.type('#testTextarea', 'test textarea value')
-  //       await page.click('#testCheckbox')
-  //       await page.click('#testRadioButton')
+    describe('stabilizes DOM', () => {
+      before(async () => {
+        await page.goto(`http://localhost:${PORT}/stabilize-dom.html`)
+      })
 
-  //       const domSnapshot = await snapshot(page, 'Serialize input elements')
-  //       expect(domSnapshot).to.contain('test input value')
-  //       expect(domSnapshot).to.contain('type="checkbox" checked')
-  //       expect(domSnapshot).to.contain('type="radio" checked')
-  //       expect(domSnapshot).to.contain('test textarea value')
-  //     })
-  //   })
+      it('serializes input elements', async () => {
+        await page.type('#testInputText', 'test input value')
+        await page.type('#testTextarea', 'test textarea value')
+        await page.click('#testCheckbox')
+        await page.click('#testRadioButton')
 
-  //   describe('stablizes CSSOM', () => {
-  //     before(async () => {
-  //       await page.goto(`http://localhost:${PORT}/stabilize-cssom.html`)
-  //     })
+        const domSnapshot = await snapshot(page, 'Serialize input elements')
+        expect(domSnapshot).to.contain('test input value')
+        expect(domSnapshot).to.contain('type="checkbox" checked')
+        expect(domSnapshot).to.contain('type="radio" checked')
+        expect(domSnapshot).to.contain('test textarea value')
+      })
+    })
 
-  //     it('serializes the CSSOM', async () => {
-  //       const domSnapshot = await snapshot(page, 'Serialize CSSOM')
+    describe('stablizes CSSOM', () => {
+      before(async () => {
+        await page.goto(`http://localhost:${PORT}/stabilize-cssom.html`)
+      })
 
-  //       expect(domSnapshot).to.contain('data-percy-cssom-serialized')
-  //       expect(domSnapshot).to.contain('.box { height: 500px; width: 500px; background-color: green; }')
+      it('serializes the CSSOM', async () => {
+        const domSnapshot = await snapshot(page, 'Serialize CSSOM')
 
-  //       // we want to ensure mutiple snapshots are successful
-  //       const secondDomSnapshot = await snapshot(page, 'Serialize CSSOM twice')
-  //       expect(secondDomSnapshot).to.contain('data-percy-cssom-serialized')
-  //       expect(secondDomSnapshot).to.contain('.box { height: 500px; width: 500px; background-color: green; }')
+        expect(domSnapshot).to.contain('data-percy-cssom-serialized')
+        expect(domSnapshot).to.contain('.box { height: 500px; width: 500px; background-color: green; }')
 
-  //     })
-  //   })
-  // })
+        // we want to ensure mutiple snapshots are successful
+        const secondDomSnapshot = await snapshot(page, 'Serialize CSSOM twice')
+        expect(secondDomSnapshot).to.contain('data-percy-cssom-serialized')
+        expect(secondDomSnapshot).to.contain('.box { height: 500px; width: 500px; background-color: green; }')
+
+      })
+    })
+  })
 })


### PR DESCRIPTION
## What is this?

The dependencies that were pulled from the `npm` registry are back. So this means CI will run again thanks to: https://github.com/jfhbrook/node-ecstatic/pull/256