### PR TITLE
fix: Make `snapshot` command visible

### DIFF
--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -7,7 +7,7 @@ import PercyCommand from './percy-command'
 
 export default class Snapshot extends PercyCommand {
   static description = 'Snapshot a directory containing a pre-built static website'
-  static hidden = true
+  static hidden = false
 
   static args = [{
     name: 'snapshotDirectory',


### PR DESCRIPTION
```
~/Code/percy-agent(david-jones/show-snapshot-command ✗) ./bin/run --help
An agent process for integrating with Percy.

VERSION
  @percy/agent/0.4.4 darwin-x64 node-v8.10.0

USAGE
  $ percy [COMMAND]

COMMANDS
  exec      Start and stop Percy around a supplied command
  finalize  finalize a build
  help      display help for percy
  snapshot  Snapshot a directory containing a pre-built static website
```

^ now shows up in help like this ^ and will also show up on the readme on release.