### PR TITLE
test: Avoid superagent double callback warning

### DIFF
--- a/test/services/static-snapshot-service.test.ts
+++ b/test/services/static-snapshot-service.test.ts
@@ -35,13 +35,10 @@ describe('StaticSnapshotService', () => {
     it('starts serving the static site on supplied port', async () => {
       await captureStdOut(() => subject.start())
 
-      await chai.request(localUrl)
-        .get('/')
-        .end((error, response) => {
-          expect(error).to.be.eq(null)
-          expect(response).to.have.status(200)
-          expect(response).to.have.header('content-type', /text\/html/)
-        })
+      const response = await chai.request(localUrl).get('/index.html')
+
+      expect(response).to.have.status(200)
+      expect(response).to.have.header('content-type', /text\/html/)
     })
 
     it('logs to stdout that it is starting the static snapshot service', async () => {
@@ -97,11 +94,11 @@ describe('StaticSnapshotService', () => {
         await subject.stop()
       })
 
-      await chai.request(localUrl)
-        .get('/')
-        .catch(async (error) => {
-          await expect(error).to.have.property('message', `connect ECONNREFUSED 127.0.0.1:${staticSitePort}`)
-        })
+      try {
+        await chai.request(localUrl).get('/')
+      } catch (error) {
+        expect(error).to.have.property('message', `connect ECONNREFUSED 127.0.0.1:${staticSitePort}`)
+      }
     })
 
     it('logs to stdout that it is stopping the static snapshot service', async () => {


### PR DESCRIPTION
Resolves this warning:

```
Warning: superagent request was sent twice, because both .end() and .then() were called. Never call .end() if you use promises
Warning: .end() was called twice. This is not supported in superagent
superagent: double callback bug
```