### PR TITLE
build: dual release `@percy/agent` and `percy` packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,9 @@ jobs:
       - checkout
       - run: npm ci
       - run: npx semantic-release
-
+      - run: sed -i '' 's/@percy\/agent/percy/g' package.json
+      - run: npm ci
+      - run: npx semantic-release
 workflows:
   version: 2
   "@percy/agent":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - checkout
       - run: npm ci
       - run: npx semantic-release
-      - run: sed -i '' 's/@percy\/agent/percy/g' package.json
+      - run: sed -i 's/@percy\/agent/percy/g' package.json
       - run: npm ci
       - run: npx semantic-release
 workflows:


### PR DESCRIPTION
We recently acquired the ["percy" package on npm](https://www.npmjs.com/package/percy). This will allow us to have extra nice commands like `npx percy snapshot _site/`.

To start we've decided to dual publish `@percy/agent` and `percy` packages. It's a wee bit tricky to test this run but this is my best guess at making it work.

P.S. a big thank you to @mauricebutler for graciously handing over ownership of the `percy` npm package.