### PR TITLE
fix: Disable HTTPS errors for asset discovery

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -35,7 +35,11 @@ export default class AssetDiscoveryService extends PercyClientService {
   async setup() {
     profile('-> assetDiscoveryService.puppeteer.launch')
     this.browser = await puppeteer.launch({
-      args: ['--no-sandbox'],
+      args: [
+        '--no-sandbox',
+        '--disable-web-security',
+      ],
+      ignoreHTTPSErrors: true,
       handleSIGINT : false,
     })
     profile('-> assetDiscoveryService.puppeteer.launch')

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -26,6 +26,7 @@ describe('Integration test', () => {
   before(async () => {
     browser = await puppeteer.launch({
       headless: true,
+      ignoreHTTPSErrors: true,
       args: [
         '--disable-gpu',
         '--no-sandbox',
@@ -54,6 +55,13 @@ describe('Integration test', () => {
       await page.goto('https://example.com')
       const domSnapshot = await snapshot(page, 'Example.com HTTPS snapshot')
       expect(domSnapshot).contains('Example Domain')
+    })
+
+    it('snapshots an invalid HTTPS site', async () => {
+      // maintained by the chrome team
+      await page.goto('https://self-signed.badssl.com/')
+      const domSnapshot = await snapshot(page, 'Invalid HTTPS')
+      expect(domSnapshot).contains('badssl.com')
     })
 
     it('snapshots a complex website with responsive images', async () => {


### PR DESCRIPTION
## What is this? 

This is so the asset discovery service doesn't fail to capture assets for snapshots that are done on invalid HTTPS sites. Without this the assets would be missing from the snapshots (as seen in this PRs first commit Percy build).

The test that's included here will be missing styles if the snapshot fails -- but the test suite will not fail. The Percy build _will_ have diffs though. 
