### PR TITLE
fix: Strip host from static snapshot names

### DIFF
--- a/src/services/static-snapshot-service.ts
+++ b/src/services/static-snapshot-service.ts
@@ -54,9 +54,12 @@ export default class StaticSnapshotService {
         path: percyAgentClientFilename,
       })
 
-      await page.evaluate((name) => {
+      await page.evaluate((url) => {
         const percyAgentClient = new PercyAgent()
-        return percyAgentClient.snapshot(name)
+        const parsedURL = new URL(url)
+        const snapshotName = parsedURL.pathname || url
+
+        return percyAgentClient.snapshot(snapshotName)
       }, url)
     }
 


### PR DESCRIPTION
## What is this? 

This will turn a snapshot name from `http://localhost:5339/index.html` to `/index.html`

This is so if anyone changes the hostname or port, it doesn't mess up their snapshot baseline