### PR TITLE
ci: Separate test commands to different steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,11 @@ jobs:
       - run: |
           mkdir -p reports
           $NYC yarn test --reporter mocha-junit-reporter
+      - run:
           $NYC yarn test-client --singleRun
+      - run:
           $NYC yarn test-integration
+      - run:
           $NYC report --reporter text-lcov > coverage.lcov
       - store_test_results: &store_test_results
           path: ~/cli/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,15 +17,20 @@ jobs:
       - run: npm install -D nyc@11 @oclif/nyc-config@1 mocha-junit-reporter@1
       - run: ./bin/run --version
       - run: ./bin/run --help
-      - run: |
-          mkdir -p reports
-          $NYC yarn test --reporter mocha-junit-reporter
       - run:
-          $NYC yarn test-client --singleRun
+          name: Unit tests
+          command: |
+            mkdir -p reports
+            $NYC yarn test --reporter mocha-junit-reporter
       - run:
-          $NYC yarn test-integration
+          name: Client tests
+          command: $NYC yarn test-client --singleRun
       - run:
-          $NYC report --reporter text-lcov > coverage.lcov
+          name: Integration tests
+          command: $NYC yarn test-integration
+      - run:
+          name: Gather reports
+          command: $NYC report --reporter text-lcov > coverage.lcov
       - store_test_results: &store_test_results
           path: ~/cli/reports
   node-8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,18 @@ jobs:
       - restore_cache: &restore_cache
           keys:
             - v2-yarn-{{checksum ".circleci/config.yml"}}-{{ checksum "package-lock.json"}}
-      - run: npm ci
-      - run: npm install -D nyc@11 @oclif/nyc-config@1 mocha-junit-reporter@1
-      - run: ./bin/run --version
-      - run: ./bin/run --help
+      - run:
+          name: Install project dependencies
+          command: npm ci
+      - run:
+          name: Install CI only dependencies
+          command: npm install -D --no-package-lock nyc@11 @oclif/nyc-config@1 mocha-junit-reporter@1
+      - run:
+          name: Version command
+          command: ./bin/run --version
+      - run:
+          name: Help command
+          command: ./bin/run --help
       - run:
           name: Unit tests
           command: |


### PR DESCRIPTION
## What is this?

This PR splits the various test commands we run in CI into their own specific (and labeled) steps. I believe a lot of the flakey tests we were seeing were due to all the tests running right after each other. This could cause race conditions where Karma is still cleaning up and freeing up resources when the puppeteer browser was launching and starting.

I've noticed the puppeteer integration tests are a little faster (from the mocha reporter) after this change. 

This is the first stab at fixing our flakey tests. I want to try and make small & incremental changes so we know what the root cause was as we work through it. 