### PR TITLE
ci: Remove loop over test cases for explicit test cases

### DIFF
--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -93,12 +93,26 @@ describe('Integration test', () => {
       server.close()
     })
 
-    it('snapshots all test cases', async () => {
-      const testFiles = fs.readdirSync(testCaseDir).filter((fn) => fn.endsWith('.html'))
-      for (const fname of testFiles) {
-        await page.goto(`http://localhost:${PORT}/${fname}`)
-        await snapshot(page, `Test case: ${fname}`)
-      }
+    describe('large resources', () => {
+      it('snapshots large DOM', async () => {
+        await page.goto(`http://localhost:${PORT}/exceeds-dom-snapshot-size-limit.html`)
+
+        await snapshot(page, 'Large DOM  snapshot')
+      })
+
+      it('snapshots pages with large assets', async () => {
+        await page.goto(`http://localhost:${PORT}/exceeds-resource-size-limit.html`)
+
+        await snapshot(page, 'Large DOM  snapshot')
+      })
+    })
+
+    describe('responsive  assets', () => {
+      it('properly  captures all assets', async () => {
+        await page.goto(`http://localhost:${PORT}/responsive-assets.html`)
+
+        await snapshot(page, 'Responsive assets')
+      })
     })
 
     describe('stabilizes DOM', () => {

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -97,13 +97,13 @@ describe('Integration test', () => {
       it('snapshots large DOM', async () => {
         await page.goto(`http://localhost:${PORT}/exceeds-dom-snapshot-size-limit.html`)
 
-        await snapshot(page, 'Large DOM  snapshot')
+        await snapshot(page, 'Large DOM snapshot')
       })
 
       it('snapshots pages with large assets', async () => {
         await page.goto(`http://localhost:${PORT}/exceeds-resource-size-limit.html`)
 
-        await snapshot(page, 'Large DOM  snapshot')
+        await snapshot(page, 'Large assets snapshot')
       })
     })
 


### PR DESCRIPTION
## What is this?

I'm not really a fan of loops in tests and this is a good example for why. The two large resource snapshots in that loop took `2055ms` & `2186ms`, which takes almost all of the timeout. So then the following 3-4 files in that loop have like `400ms` to work with to do everything. Sometimes they can complete, other times it fails because it hit the timeout.

This commit makes all of the tests their own asserts so they get a full 5000ms
to work with individually.