### PR TITLE
fix: Static service Wait for network idle

### DIFF
--- a/src/services/static-snapshot-service.ts
+++ b/src/services/static-snapshot-service.ts
@@ -49,7 +49,7 @@ export default class StaticSnapshotService {
     for (const url of pageUrls) {
       logger.debug(`visiting ${url}`)
 
-      await page.goto(url)
+      await page.goto(url, { waitUntil: 'networkidle0' })
 
       await page.addScriptTag({
         path: percyAgentClientFilename,


### PR DESCRIPTION
## What is this? 

I've been seeing a lot of errors like:

```
Error: Execution context was destroyed, most likely because of a navigation.
```

This happens because we try to start altering the page (by injecting our JS) before everything is settled down. This change won't promise the page has actually loaded (that's very hard to determine) but it will wait for most network requests to resolve before trying do anything.