### PR TITLE
fix: Pin `@oclif/command` to `1.5.16`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
           name: Help command
           command: ./bin/run --help
       - run:
+          name: Build package
+          command: npm run build
+      - run:
           name: Unit tests
           command: |
             mkdir -p reports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,38 +1382,16 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.18",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.18.tgz",
-      "integrity": "sha512-sfLb5UUCwyQ0w9LyQ1/3DUuD/RWnPZk6uvcK5P7pqD65WgRJaOPCqzuNZyb56kPsj6FftRp1UudApNKd7U0KBQ==",
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.16.tgz",
+      "integrity": "sha512-bzqNz9/EblkohokXbico/14r05oRe8aa06S3MLEo4GlmyOce2abIOx1oZfUDl8ekQuKO+Ycw9Jco+hN2aL423A==",
       "requires": {
-        "@oclif/config": "^1",
         "@oclif/errors": "^1.2.2",
-        "@oclif/parser": "^3.8.3",
-        "@oclif/plugin-help": "^2",
+        "@oclif/parser": "^3.7.3",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
       },
       "dependencies": {
-        "@oclif/parser": {
-          "version": "3.8.4",
-          "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.4.tgz",
-          "integrity": "sha512-cyP1at3l42kQHZtqDS3KfTeyMvxITGwXwH1qk9ktBYvqgMp5h4vHT+cOD74ld3RqJUOZY/+Zi9lb4Tbza3BtuA==",
-          "requires": {
-            "@oclif/linewrap": "^1.0.0",
-            "chalk": "^2.4.2",
-            "tslib": "^1.9.3"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "bugs": "https://github.com/percy/percy-agent/issues",
   "dependencies": {
-    "@oclif/command": "1.5.18",
+    "@oclif/command": "1.5.16",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "@oclif/plugin-not-found": "^1.2",


### PR DESCRIPTION
## What is this? 

v1.5.17 introduces type changes that breaks our build (even though the code is fine and the same): https://github.com/oclif/command/compare/v1.5.16...v1.5.17

Until we can unbreak TS, we'll stick to this version.