### PR TITLE
feat: Support capturing assets from allowed hostnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "preversion": "npm run clean",
     "test": "npm run build-client && PERCY_TOKEN=abc mocha --forbid-only \"test/**/*.test.ts\" --exclude \"test/percy-agent-client/**/*.test.ts\" --exclude \"test/integration/**/*\"",
     "test-client": "karma start ./test/percy-agent-client/karma.conf.js",
-    "test-integration": "npm run build-client && node ./bin/run exec -- mocha test/integration/**/*.test.ts",
+    "test-integration": "npm run build-client && node ./bin/run exec -h localtest.me -- mocha test/integration/**/*.test.ts",
     "test-snapshot-command": "./bin/run snapshot test/integration/test-static-site -b /dummy-base-url -i '(red-keep)' -c '\\.(html)$'",
     "version": "oclif-dev readme && git add README.md",
     "watch": "npm-watch"

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -17,7 +17,7 @@ export default class Exec extends PercyCommand {
   static flags = {
     'allowed-hostname': flags.string({
       char: 'h',
-      description: 'hostnames that assets should be captured from',
+      description: 'Allowable hostname(s) to capture assets from',
       multiple: true,
     }),
     'network-idle-timeout': flags.integer({

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -15,6 +15,11 @@ export default class Exec extends PercyCommand {
   ]
 
   static flags = {
+    'allowed-hostname': flags.string({
+      char: 'h',
+      description: 'hostnames that assets should be captured from',
+      multiple: true,
+    }),
     'network-idle-timeout': flags.integer({
       char: 't',
       default: DEFAULT_CONFIGURATION.agent['asset-discovery']['network-idle-timeout'],

--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -38,6 +38,11 @@ export default class Snapshot extends PercyCommand {
       'of the webserver\'s root path, set that subdirectory with this flag.',
       default: DEFAULT_CONFIGURATION['static-snapshots']['base-url'],
     }),
+    'allowed-hostname': flags.string({
+      char: 'h',
+      description: 'Allowable hostname(s) to capture assets from',
+      multiple: true,
+    }),
     // from exec command. needed to start the agent service.
     'network-idle-timeout': flags.integer({
       char: 't',

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -21,7 +21,7 @@ export default class Start extends PercyCommand {
     }),
     'allowed-hostname': flags.string({
       char: 'h',
-      description: 'hostnames that assets should be captured from',
+      description: 'Allowable hostname(s) to capture assets from',
       multiple: true,
     }),
     'network-idle-timeout': flags.integer({

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -19,6 +19,11 @@ export default class Start extends PercyCommand {
       char: 'd',
       description: 'start as a detached process',
     }),
+    'allowed-hostname': flags.string({
+      char: 'h',
+      description: 'hostnames that assets should be captured from',
+      multiple: true,
+    }),
     'network-idle-timeout': flags.integer({
       char: 't',
       default: DEFAULT_CONFIGURATION.agent['asset-discovery']['network-idle-timeout'],

--- a/src/configuration/asset-discovery-configuration.ts
+++ b/src/configuration/asset-discovery-configuration.ts
@@ -1,4 +1,5 @@
 export interface AssetDiscoveryConfiguration {
+  'allowed-hostnames': string[],
   'network-idle-timeout': number,
   'page-pool-size-min': number,
   'page-pool-size-max': number

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -19,6 +19,7 @@ export const DEFAULT_CONFIGURATION: Configuration = {
   'agent': {
     'port': DEFAULT_PORT,
     'asset-discovery': {
+      'allowed-hostnames': [],
       'network-idle-timeout': 50, // ms
       'page-pool-size-min': 1, // pages
       'page-pool-size-max': 5, // pages

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -19,10 +19,10 @@ export class AssetDiscoveryService extends PercyClientService {
 
   constructor(buildId: number, configuration?: AssetDiscoveryConfiguration) {
     super()
-    this.responseService = new ResponseService(buildId)
     this.browser = null
     this.pagePool = null
     this.configuration = configuration || DEFAULT_CONFIGURATION.agent['asset-discovery']
+    this.responseService = new ResponseService(buildId, this.configuration['allowed-hostnames'])
   }
 
   async setup() {

--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -39,6 +39,10 @@ export default class ConfigurationService {
       this.configuration.agent.port = flags.port
     }
 
+    if (flags['allowed-hostname']) {
+      this.configuration.agent['asset-discovery']['allowed-hostnames'] = flags['allowed-hostname']
+    }
+
     if (flags['network-idle-timeout']) {
       this.configuration.agent['asset-discovery']['network-idle-timeout'] = flags['network-idle-timeout']
     }

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -29,7 +29,8 @@ export default class ResponseService extends PercyClientService {
     }
 
     // Capture if the resourceUrl has a hostname in the allowedHostnames
-    if (this.allowedHostnames.some((hostname) => resourceUrl.startsWith(hostname))) {
+    const parsedResourceUrl = new URL(resourceUrl)
+    if (this.allowedHostnames.some((hostname) => parsedResourceUrl.hostname === hostname)) {
       return true
     }
 

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -14,10 +14,27 @@ export default class ResponseService extends PercyClientService {
 
   readonly ALLOWED_RESPONSE_STATUSES = [200, 201, 304]
   responsesProcessed: Map<string, string> = new Map()
+  allowedHostnames: string[]
 
-  constructor(buildId: number) {
+  constructor(buildId: number, allowedHostnames: string[]) {
     super()
     this.resourceService = new ResourceService(buildId)
+    this.allowedHostnames = allowedHostnames
+  }
+
+  shouldCaptureResource(rootUrl: string, resourceUrl: string): boolean {
+    // Capture if the resourceUrl is the same as the rootUrL
+    if (resourceUrl.startsWith(rootUrl)) {
+      return true
+    }
+
+    // Capture if the resourceUrl has a hostname in the allowedHostnames
+    if (this.allowedHostnames.some((hostname) => resourceUrl.startsWith(hostname))) {
+      return true
+    }
+
+    // Resource is not allowed
+    return false
   }
 
   async processResponse(rootResourceUrl: string, response: puppeteer.Response, width: number): Promise<any | null> {
@@ -44,13 +61,13 @@ export default class ResponseService extends PercyClientService {
       return
     }
 
-    if (!request.url().startsWith(rootUrl)) {
+    if (!this.shouldCaptureResource(rootUrl, request.url())) {
       // Disallow remote resource requests.
       logger.debug(`Skipping [is_remote_resource] [${width} px]: ${request.url()}`)
       return
     }
 
-    if (!response.url().startsWith(rootUrl)) {
+    if (!this.shouldCaptureResource(rootUrl, response.url())) {
       // Disallow remote redirects.
       logger.debug(`Skipping [is_remote_redirect] [${width} px]: ${response.url()}`)
       return

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -1,5 +1,4 @@
 import * as cheerio from 'cheerio'
-import * as fs from 'fs'
 import { Server } from 'http'
 import * as httpServer from 'http-server'
 import { describe } from 'mocha'
@@ -117,11 +116,19 @@ describe('Integration test', () => {
       })
     })
 
-    describe('responsive  assets', () => {
-      it('properly  captures all assets', async () => {
+    describe('responsive assets', () => {
+      it('properly captures all assets', async () => {
         await page.goto(`http://localhost:${PORT}/responsive-assets.html`)
 
         await snapshot(page, 'Responsive assets')
+      })
+    })
+
+    describe('alternate hostnames', () => {
+      it('properly captures assets from alternate hostnames', async () => {
+        await page.goto(`http://localhost:${PORT}/alternate-hostname.html`)
+
+        await snapshot(page, 'Alternate hostname')
       })
     })
 

--- a/test/integration/testcases/alternate-hostname.html
+++ b/test/integration/testcases/alternate-hostname.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html><head>
+    <title>Alternate hostname testing</title>
+</head>
+<body>
+  <div>
+    <p>
+      If alternate hostname support is working, there should be an svg image of the vue logo below.
+    </p>
+    <p>
+      It works because localhost.me resolves to 127.0.0.1, allowing us to serve the vue logo over
+      it, and we start the integration tests by specifying localhost.me as an allowed-hostname
+      with the -h flag.
+    </p>
+    <img src="http://localtest.me:8000/vue.svg">
+  </div>
+</body>
+</html>

--- a/test/integration/testcases/vue.svg
+++ b/test/integration/testcases/vue.svg
@@ -1,0 +1,6 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="48" height="48"/>
+<path d="M38.4 3H48L24 44.4L0 3H9.48H18.36L24 12.6L29.52 3H38.4Z" fill="#41B883"/>
+<path d="M0 3L24 44.4L48 3H38.4L24 27.84L9.48 3H0Z" fill="#41B883"/>
+<path d="M9.47949 3L23.9995 27.96L38.3995 3H29.5195L23.9995 12.6L18.3595 3H9.47949Z" fill="#35495E"/>
+</svg>

--- a/test/services/configuration-service.test.ts
+++ b/test/services/configuration-service.test.ts
@@ -42,6 +42,7 @@ describe('ConfigurationService', () => {
         'base-url': '/flag/',
         'snapshot-files': 'flags/*.html',
         'ignore-files': 'ignore-flags/*.html',
+        'allowed-hostname': ['additional-hostname.local'],
       }
       const subject = new ConfigurationService('test/support/.percy.yml').applyFlags(flags)
 
@@ -49,6 +50,9 @@ describe('ConfigurationService', () => {
       expect(subject['static-snapshots']['snapshot-files']).to.eql('flags/*.html')
       expect(subject['static-snapshots']['ignore-files']).to.eql('ignore-flags/*.html')
       expect(subject.agent['asset-discovery']['network-idle-timeout']).to.eql(51)
+      expect(subject.agent['asset-discovery']['allowed-hostnames']).to.eql(
+        ['additional-hostname.local'],
+      )
     })
   })
 

--- a/test/services/configuration-service.test.ts
+++ b/test/services/configuration-service.test.ts
@@ -23,6 +23,7 @@ describe('ConfigurationService', () => {
       expect(subject['static-snapshots']['snapshot-files']).to.eql('**/*.html')
       expect(subject['static-snapshots']['ignore-files']).to.eql('**/*.htm')
       expect(subject.agent.port).to.eql(1111)
+      expect(subject.agent['asset-discovery']['allowed-hostnames']).to.eql(['localassets.dev'])
       expect(subject.agent['asset-discovery']['network-idle-timeout']).to.eql(50)
       expect(subject.agent['asset-discovery']['page-pool-size-min']).to.eql(5)
       expect(subject.agent['asset-discovery']['page-pool-size-max']).to.eql(20)

--- a/test/support/.percy.yml
+++ b/test/support/.percy.yml
@@ -11,6 +11,8 @@ static-snapshots:
 agent:
   port: 1111
   asset-discovery:
+    allowed-hostnames:
+      - localassets.dev
     network-idle-timeout: 50 # ms
     page-pool-size-min: 5 # pages
     page-pool-size-max: 20 # pages


### PR DESCRIPTION
Adds support for allowed hostnames that assets should be captured from.

If a hostname is specified, any requests to assets on that hostname will be captured, and they'll be uploaded to Percy's API as snapshot resources.  During rendering time, **http** requests to the captured asset's url will be hijacked, and the captured resource served. 

Hostnames can be provided either with the `-allowed-hostname` or `-h` flag, or they can be specified in the `.percy.yml` file as an array under agent -> asset-discovery -> allowed-hostnames.

The main function is tested with the new alternate-hostname integration test. It loads a vue.svg file from a hostname of localhost.me. Localhost.me resolves to 127.0.0.1, so we can serve it from our local dev/CI environment, and be sure that the captured asset is being served in production. 

Note: requests to https assets won't be successfully highjacked in our rendering environment yet, but this PR should include the appropriate support for capturing them to our @percy/agent based SDKs.