### PR TITLE
fix: Stop and finalize build on exec termination

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -1,4 +1,4 @@
-import {flags} from '@oclif/command'
+import { flags } from '@oclif/command'
 import * as spawn from 'cross-spawn'
 import { DEFAULT_CONFIGURATION } from '../configuration/configuration'
 import ConfigurationService from '../services/configuration-service'
@@ -35,9 +35,7 @@ export default class Exec extends PercyCommand {
   async run() {
     await super.run()
 
-    const {argv} = this.parse(Exec)
-    const {flags} = this.parse(Exec)
-
+    const { argv, flags } = this.parse(Exec)
     const command = argv.shift()
 
     if (!command) {
@@ -54,14 +52,20 @@ export default class Exec extends PercyCommand {
     }
 
     // Even if Percy will not run, continue to run the subprocess
-    const spawnedProcess = spawn(command, argv, {stdio: 'inherit'})
+    const spawnedProcess = spawn(command, argv, { stdio: 'inherit' })
+    spawnedProcess.on('exit', (code) => this.stop(code))
 
-    spawnedProcess.on('exit', async (code: any) => {
-      if (this.percyWillRun()) {
-        await this.agentService.stop()
-      }
+    // Recieving any of these events should stop the agent and exit
+    process.on('SIGHUP', () => this.stop())
+    process.on('SIGINT', () => this.stop())
+    process.on('SIGTERM', () => this.stop())
+  }
 
-      process.exit(code)
-    })
+  async stop(exitCode?: number | null) {
+    if (this.percyWillRun()) {
+      await this.agentService.stop()
+    }
+
+    process.exit(exitCode || 0)
   }
 }

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -58,7 +58,7 @@ export default class Exec extends PercyCommand {
     const spawnedProcess = spawn(command, argv, { stdio: 'inherit' })
     spawnedProcess.on('exit', (code) => this.stop(code))
 
-    // Recieving any of these events should stop the agent and exit
+    // Receiving any of these events should stop the agent and exit
     process.on('SIGHUP', () => this.stop())
     process.on('SIGINT', () => this.stop())
     process.on('SIGTERM', () => this.stop())

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -32,6 +32,9 @@ export default class Exec extends PercyCommand {
     }),
   }
 
+  // helps prevent exiting before the agent service has stopped
+  private exiting = false
+
   async run() {
     await super.run()
 
@@ -61,7 +64,10 @@ export default class Exec extends PercyCommand {
     process.on('SIGTERM', () => this.stop())
   }
 
-  async stop(exitCode?: number | null) {
+  private async stop(exitCode?: number | null) {
+    if (this.exiting) { return }
+    this.exiting = true
+
     if (this.percyWillRun()) {
       await this.agentService.stop()
     }

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -22,7 +22,7 @@ export default class PercyCommand extends Command {
   }
 
   async run() {
-    if (this.percyEnabled && !this.percyTokenPresent()) {
+    if (this.percyEnabled() && !this.percyTokenPresent()) {
       this.warn('Skipping visual tests. PERCY_TOKEN was not provided.')
     }
   }

--- a/test/commands/percy-command.test.ts
+++ b/test/commands/percy-command.test.ts
@@ -14,15 +14,13 @@ describe('percy-command', () => {
     .stub(process, 'env', {PERCY_ENABLE: '0', PERCY_TOKEN: ''})
     .stderr()
     .command(['percy-command'])
-    .do((output) => expect(output.stderr).to.contain(
-      'Warning: Skipping visual tests. PERCY_TOKEN was not provided.',
-    ))
-    .it('warns about PERCY_TOKEN to be set')
+    .do((output) => expect(output.stderr).to.eql(''))
+    .it('outputs no warnings when PERCY_ENABLED is 0')
 
   test
-    .stub(process, 'env', {PERCY_ENABLE: '0', PERCY_TOKEN: 'ABC'})
+    .stub(process, 'env', {PERCY_TOKEN: 'ABC'})
     .stderr()
     .command(['percy-command'])
     .do((output) => expect(output.stderr).to.eql(''))
-    .it('outputs no errors')
+    .it('outputs no errors when PERCY_TOKEN is set')
 })


### PR DESCRIPTION
## Purpose

When running `percy exec` with a command that causes the process to hang, terminating the process causes builds to get stuck in a receiving state due to the build never finalizing.

## Approach

Add [signal handlers](https://nodejs.org/api/process.html#process_signal_events) for `SIGHUP`, `SIGINT`, and `SIGTERM` to stop and finalize the build.

Multiple signals are sometimes sent and cause the stop method to get called multiple times. This didn't seem to effect finalizing builds, but caused noisy output in the terminal. An instance property, `exiting`, is used to bail out of the stop method when it has already been called. This also prevents secondary events from exiting before the first event has finalized the build.

### Other changes

I also corrected a check for `percyEnabled` which treated the property as a getter when it is actually a method. Fixing this also highlighted a test which actually tested the incorrect behavior. This test was updated to reflect the desired behavior, which is to not warn about a missing token when Percy is disabled.