### PR TITLE
test: Make ignore snapshot test more explicit

### DIFF
--- a/test/services/static-snapshot-service.test.ts
+++ b/test/services/static-snapshot-service.test.ts
@@ -59,6 +59,7 @@ describe('StaticSnapshotService', () => {
 
       expect(pages[0]).to.equal(expectedUrls[0])
       expect(pages[1]).to.equal(expectedUrls[1])
+      expect(pages.length).to.equal(2)
     })
 
   })
@@ -87,6 +88,7 @@ describe('StaticSnapshotService', () => {
       expect(pages[0]).to.equal(expectedUrls[0])
       expect(pages[1]).to.equal(expectedUrls[1])
       expect(pages[2]).to.equal(expectedUrls[2])
+      expect(pages.length).to.equal(3)
     })
   })
 


### PR DESCRIPTION
## What is this?

We randonly get test fails from the static snapshot commands `_buildPageUrls` unit test. An example of the failure can be seen here: https://circleci.com/gh/percy/percy-agent/2767

This doesn't exactly fix the issue, but it will make the error clear when it occurs the next time. Right now we just now the array doesn't deeply equal, but we're not sure _which_ item it is.