### PR TITLE
feat: Add configuration option to enable javascript

### DIFF
--- a/src/configuration/snapshot-configuration.ts
+++ b/src/configuration/snapshot-configuration.ts
@@ -1,4 +1,5 @@
 export interface SnapshotConfiguration {
   widths: number[],
   'min-height': number,
+  'enable-javascript'?: boolean
 }

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -92,7 +92,9 @@ export class AgentService {
     const configuration = new ConfigurationService().configuration
     const snapshotOptions: SnapshotOptions = {
       widths: request.body.widths || configuration.snapshot.widths,
-      enableJavaScript: request.body.enableJavaScript,
+      enableJavaScript: request.body.enableJavaScript != null
+        ? request.body.enableJavaScript
+        : configuration.snapshot['enable-javascript'],
       minHeight: request.body.minHeight || configuration.snapshot['min-height'],
     }
 

--- a/test/services/configuration-service.test.ts
+++ b/test/services/configuration-service.test.ts
@@ -17,6 +17,7 @@ describe('ConfigurationService', () => {
       expect(subject.version).to.eql(1)
       expect(subject.snapshot.widths).to.eql([375, 1280])
       expect(subject.snapshot['min-height']).to.eql(1024)
+      expect(subject.snapshot['enable-javascript']).to.eql(true)
       expect(subject['static-snapshots'].path).to.eql('_site/')
       expect(subject['static-snapshots'].port).to.eql(9999)
       expect(subject['static-snapshots']['base-url']).to.eql('/blog/')

--- a/test/support/.percy.yml
+++ b/test/support/.percy.yml
@@ -2,6 +2,7 @@ version: 1
 snapshot:
   widths: [375, 1280]
   min-height: 1024 # px
+  enable-javascript: true
 static-snapshots:
   path: _site/
   port: 9999


### PR DESCRIPTION
## Purpose

Enabling JavaScript must be done on a per-snapshot basis and in rare cases where the user needs to enable it for every snapshot, it becomes tedious to add it to every snapshot call.

## Approach

Add an `enable-javascript` option to the configuration file to enable setting this option for all snapshots in a single setting.

I know we don't recommend setting this option _normally_, however if needed it can be a pain to set this for every single snapshot.