### PR TITLE
Feat: Automatically capture Winston logs per-snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "percy-client": "^3.0.3",
     "puppeteer": "^1.13.0",
     "retry-axios": "^1.0.1",
-    "winston": "^2.0.0"
+    "winston": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -9,7 +9,7 @@ export default class PercyCommand extends Command {
 
   agentService: AgentService
   processService: ProcessService
-  logger: winston.LoggerInstance
+  logger: winston.Logger
   percyToken: string
 
   constructor(argv: string[], config: any) {

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -113,6 +113,7 @@ export class AgentService {
       request.body.url,
       domSnapshot,
       snapshotOptions,
+      snapshotLogger,
     )
 
     resources = resources.concat(

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import logger, {logError, profile} from '../utils/logger'
+import { logError, profile } from '../utils/logger'
 import PercyClientService from './percy-client-service'
 
 export default class ResourceService extends PercyClientService {
@@ -11,7 +11,7 @@ export default class ResourceService extends PercyClientService {
     this.buildId = buildId
   }
 
-  createResourceFromFile(responseUrl: string, copyFilePath: string, contentType = ''): any {
+  createResourceFromFile(responseUrl: string, copyFilePath: string, contentType = '', logger: any): any {
     const copyFullPath = path.resolve(copyFilePath)
     const sha = path.basename(copyFilePath)
     const resourceUrl = responseUrl

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -3,8 +3,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import * as puppeteer from 'puppeteer'
-import {URL} from 'url'
-import logger from '../utils/logger'
+import { URL } from 'url'
 import Constants from './constants'
 import PercyClientService from './percy-client-service'
 import ResourceService from './resource-service'
@@ -38,7 +37,12 @@ export default class ResponseService extends PercyClientService {
     return false
   }
 
-  async processResponse(rootResourceUrl: string, response: puppeteer.Response, width: number): Promise<any | null> {
+  async processResponse(
+    rootResourceUrl: string,
+    response: puppeteer.Response,
+    width: number,
+    logger: any,
+  ): Promise<any | null> {
     logger.debug(`processing response: ${response.url()} for width: ${width}`)
     const url = this.parseRequestPath(response.url())
 
@@ -74,7 +78,7 @@ export default class ResponseService extends PercyClientService {
       return
     }
 
-    const localCopy = await this.makeLocalCopy(response)
+    const localCopy = await this.makeLocalCopy(response, logger)
 
     const responseBodySize = fs.statSync(localCopy).size
     if (responseBodySize > Constants.MAX_FILE_SIZE_BYTES) {
@@ -84,13 +88,13 @@ export default class ResponseService extends PercyClientService {
     }
 
     const contentType = response.headers()['content-type']
-    const resource = this.resourceService.createResourceFromFile(url, localCopy, contentType)
+    const resource = this.resourceService.createResourceFromFile(url, localCopy, contentType, logger)
     this.responsesProcessed.set(url, resource)
 
     return resource
   }
 
-  async makeLocalCopy(response: puppeteer.Response): Promise<string> {
+  async makeLocalCopy(response: puppeteer.Response, logger: any): Promise<string> {
     logger.debug(`Making local copy of response: ${response.url()}`)
 
     const buffer = await response.buffer()

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -1,7 +1,10 @@
+import * as crypto from 'crypto'
+import * as fs from 'fs'
+import * as path from 'path'
 import { AssetDiscoveryConfiguration } from '../configuration/asset-discovery-configuration'
-import {SnapshotOptions} from '../percy-agent-client/snapshot-options'
-import {logError, profile} from '../utils/logger'
-import {AssetDiscoveryService} from './asset-discovery-service'
+import { SnapshotOptions } from '../percy-agent-client/snapshot-options'
+import { logError, profile } from '../utils/logger'
+import { AssetDiscoveryService } from './asset-discovery-service'
 import PercyClientService from './percy-client-service'
 import ResourceService from './resource-service'
 
@@ -24,23 +27,33 @@ export default class SnapshotService extends PercyClientService {
     domSnapshot = '',
     options: SnapshotOptions,
   ): Promise<any[]> {
-    const rootResource = await this.percyClient.makeResource({
+    const rootResource = this.percyClient.makeResource({
       resourceUrl: rootResourceUrl,
       content: domSnapshot,
       isRoot: true,
       mimetype: 'text/html',
     })
 
-    let resources: any[] = []
     const discoveredResources = await this.assetDiscoveryService.discoverResources(
       rootResourceUrl,
       domSnapshot,
       options,
     )
-    resources = resources.concat([rootResource])
-    resources = resources.concat(discoveredResources)
 
-    return resources
+    return [rootResource].concat(discoveredResources)
+  }
+
+  buildLogResource(localPath: string) {
+    const fileName = path.basename(localPath)
+    const buffer = fs.readFileSync(path.resolve(localPath))
+    const sha = crypto.createHash('sha256').update(buffer).digest('hex')
+
+    return this.percyClient.makeResource({
+      resourceUrl: `/${fileName}`,
+      mimetype: 'text/plain',
+      localPath,
+      sha,
+    })
   }
 
   create(

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -26,6 +26,7 @@ export default class SnapshotService extends PercyClientService {
     rootResourceUrl: string,
     domSnapshot = '',
     options: SnapshotOptions,
+    logger: any,
   ): Promise<any[]> {
     const rootResource = this.percyClient.makeResource({
       resourceUrl: rootResourceUrl,
@@ -38,6 +39,7 @@ export default class SnapshotService extends PercyClientService {
       rootResourceUrl,
       domSnapshot,
       options,
+      logger,
     )
 
     return [rootResource].concat(discoveredResources)

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,6 +5,7 @@ const LOG_LEVEL = process.env.LOG_LEVEL || 'info'
 
 const consoleTransport = new winston.transports.Console({
   level: LOG_LEVEL,
+  stderrLevels: ['error'],
   format: winston.format.combine(
     winston.format.label({ label: colors.magenta('percy') }),
     winston.format.printf(({ label, message }) => `[${label}] ${message}`),

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,34 +1,34 @@
 import * as colors from 'colors'
 import * as winston from 'winston'
 
-const logger = new winston.Logger({
-  transports: [
-    new winston.transports.Console({
-      level: (process.env.LOG_LEVEL || 'info'),
-      showLevel: false,
-      label: colors.magenta('percy'),
-    }),
-  ],
+const LOG_LEVEL = process.env.LOG_LEVEL || 'info'
+
+const consoleTransport = new winston.transports.Console({
+  level: LOG_LEVEL,
+  format: winston.format.combine(
+    winston.format.label({ label: colors.magenta('percy') }),
+    winston.format.printf(({ label, message }) => `[${label}] ${message}`),
+  ),
 })
 
-export function profile(
-  id: string, meta?: any,
-  callback?: (err: Error, level: string, msg: string, meta: any) => void,
-): winston.LoggerInstance | undefined {
-  if (process.env.LOG_LEVEL === 'debug') {
-    // Only pass the callback through if it is defined, because the winston.Logger implementation
-    // does not behave as expected if you pass a null callback (it will ignore the meta parameter).
-    if (callback) {
-      return logger.profile(id, id, meta, callback)
-    } else {
-      return logger.profile(id, id, meta)
-    }
+const logger = winston.createLogger({
+  transports: [consoleTransport],
+})
+
+export function profile(id: string, meta?: any): winston.Logger | undefined {
+  if (LOG_LEVEL === 'debug') {
+    return logger.profile(id, { level: 'debug', ...meta })
   }
 }
 
 export function logError(error: any) {
   logger.error(`${error.name} ${error.message}`)
   logger.debug(error)
+}
+
+export function createFileLogger(filename: string) {
+  const fileTransport = new winston.transports.File({ filename, level: 'debug' })
+  return winston.createLogger({ transports: [consoleTransport, fileTransport] })
 }
 
 export default logger

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,7 +1742,7 @@ async@^1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
-async@^2.6.2:
+async@^2.6.1, async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -1753,11 +1753,6 @@ async@~0.2.9:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
   integrity sha1-trvgsGdLnXGXCMo43owjfLUmw9E=
-
-async@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
-  integrity sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2693,7 +2688,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -2705,15 +2700,49 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-colors@*, colors@^1.1.0, colors@^1.1.2, colors@^1.3.2:
+color-name@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
+  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
+
+colornames@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
+  integrity sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=
+
+colors@*, colors@^1.1.0, colors@^1.1.2, colors@^1.2.1, colors@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
-colors@1.0.3, colors@1.0.x:
+colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+
+colorspace@1.1.x:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
+  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
+  dependencies:
+    color "3.0.x"
+    text-hex "1.0.x"
 
 columnify@~1.5.4:
   version "1.5.4"
@@ -3134,11 +3163,6 @@ custom-event@~1.0.0:
   resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
   integrity sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
 
-cycle@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
-  integrity sha1-IegLK+hYD5i0aPN5QwZisEbDStI=
-
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
@@ -3383,6 +3407,15 @@ di@^0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
+diagnostics@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/diagnostics/-/diagnostics-1.1.1.tgz#cab6ac33df70c9d9a727490ae43ac995a769b22a"
+  integrity sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "1.0.x"
+    kuler "1.0.x"
+
 diff@3.5.0, diff@^3.2.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -3583,6 +3616,13 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
+enabled@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-1.0.2.tgz#965f6513d2c2d1c5f4652b64a2e3396467fc2f93"
+  integrity sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=
+  dependencies:
+    env-variable "0.0.x"
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -3707,6 +3747,11 @@ env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
   integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
+
+env-variable@0.0.x:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/env-variable/-/env-variable-0.0.5.tgz#913dd830bef11e96a039c038d4130604eba37f88"
+  integrity sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -4080,11 +4125,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-eyes@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
-  integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
-
 fancy-test@^1.4.3:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/fancy-test/-/fancy-test-1.4.4.tgz#979f2827fccafac0ef52b542ab9ba9e8bcf40e50"
@@ -4127,6 +4167,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
+  integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
+
 fastq@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
@@ -4140,6 +4185,11 @@ fd-slicer@~1.0.1:
   integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
   dependencies:
     pend "~1.2.0"
+
+fecha@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
+  integrity sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==
 
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -5218,6 +5268,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -5543,7 +5598,7 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
-isstream@0.1.x, isstream@~0.1.2:
+isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
@@ -5773,6 +5828,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+kuler@1.0.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-1.0.1.tgz#ef7c784f36c9fb6e16dd3150d152677b2b0228a6"
+  integrity sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==
+  dependencies:
+    colornames "^1.1.1"
 
 labeled-stream-splicer@^2.0.0:
   version "2.0.2"
@@ -6232,6 +6294,17 @@ log4js@^4.0.0:
     flatted "^2.0.0"
     rfdc "^1.1.4"
     streamroller "^1.0.6"
+
+logform@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.1.2.tgz#957155ebeb67a13164069825ce67ddb5bb2dd360"
+  integrity sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==
+  dependencies:
+    colors "^1.2.1"
+    fast-safe-stringify "^2.0.4"
+    fecha "^2.3.3"
+    ms "^2.1.1"
+    triple-beam "^1.3.0"
 
 lolex@^4.1.0, lolex@^4.2.0:
   version "4.2.0"
@@ -7310,6 +7383,11 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0, once@~1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+one-time@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-0.0.4.tgz#f8cdf77884826fe4dff93e3a9cc37b1e4480742e"
+  integrity sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -8802,6 +8880,13 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
   integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
+
 sinon-chai@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.3.0.tgz#8084ff99451064910fbe2c2cb8ab540c00b740ea"
@@ -9544,6 +9629,11 @@ text-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -9714,6 +9804,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 ts-node@^8.0.3:
   version "8.3.0"
@@ -10332,17 +10427,28 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-winston@^2.0.0:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.4.tgz#a01e4d1d0a103cf4eada6fc1f886b3110d71c34b"
-  integrity sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==
+winston-transport@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.3.0.tgz#df68c0c202482c448d9b47313c07304c2d7c2c66"
+  integrity sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==
   dependencies:
-    async "~1.0.0"
-    colors "1.0.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
+    readable-stream "^2.3.6"
+    triple-beam "^1.2.0"
+
+winston@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.2.1.tgz#63061377976c73584028be2490a1846055f77f07"
+  integrity sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==
+  dependencies:
+    async "^2.6.1"
+    diagnostics "^1.1.1"
+    is-stream "^1.1.0"
+    logform "^2.1.1"
+    one-time "0.0.4"
+    readable-stream "^3.1.1"
     stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.3.0"
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
## Purpose

In order to debug snapshots, sometimes support needs to ask the customer to rerun a build with `LOG_LEVEL=debug` and then request that the user send those logs. 

Sometimes this isn't feasible as some issues may not be easily reproduce-able. These logs are also interweaved with test runner logs, which may be hard to parse.

We can tell Winston to send snapshot-specific logs to a file, and upload that log file along with other snapshot resources. This allows support to see logs when downloading a snapshot for debugging without asking the customer.

## Approach

First, Winston needed to be updated to 3.x as it is much more configurable and modular than Winston 2.x. This allows us to reuse the console transport, and use separate loggers for each snapshot's own logging. The biggest change from 2.x is the format options and lack of defaults. The old format was minimally recreated for the console transport, while the file transport is left to be raw JSON.

When a snapshot is received by the agent process, the logfile is created along with the snapshot-specific logger. The snapshot logger is then passed along to the snapshot service, which then passes it along to the asset discovery service, which then passes it along to the resource service, which finally passes it along to the response service. All of these services are responsible for different aspects of each snapshot, so they each need to be aware of the snapshot-specific logger.

### Notes

- Since the content sha of a resource needs to match the sha used when a snapshot is created, we cannot send logs after-the-fact for an entire build. Logs can only be sent when the snapshot is created, hence only capturing and uploading snapshot-specific logs.

- Support may still need to debug test runner output in a case when snapshot-specific logs don't show anything suspicious. We can automatically capture this output as well, but wouldn't be able to upload it with a build (security concerns aside). We would need a way to associate resources with a build during finalization, or have a separate endpoint to upload build logs.

### TODO

- [ ] Write a test that verifies a new log is created per-snapshot. These logs use a timestamp within their name to avoid overriding each other in the tmp directory, so testing this might involve stubbing the Date to write to a stable filename.