### PR TITLE
feat: Allow wildcard hostnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "preversion": "yarn clean",
     "test": "yarn build-client && PERCY_TOKEN=abc mocha --forbid-only \"test/**/*.test.ts\" --exclude \"test/percy-agent-client/**/*.test.ts\" --exclude \"test/integration/**/*\"",
     "test-client": "karma start ./test/percy-agent-client/karma.conf.js",
-    "test-integration": "yarn build-client && node ./bin/run exec -h localtest.me -- mocha test/integration/**/*.test.ts",
+    "test-integration": "yarn build-client && node ./bin/run exec -h *.localtest.me -- mocha test/integration/**/*.test.ts",
     "test-snapshot-command": "./bin/run snapshot test/integration/test-static-site -b /dummy-base-url -i '(red-keep)' -c '\\.(html)$'",
     "version": "oclif-dev readme && git add README.md",
     "watch": "npm-watch"

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -4,6 +4,7 @@ import * as os from 'os'
 import * as path from 'path'
 import * as puppeteer from 'puppeteer'
 import { URL } from 'url'
+import domainMatch from '../utils/domain-match'
 import Constants from './constants'
 import PercyClientService from './percy-client-service'
 import ResourceService from './resource-service'
@@ -28,8 +29,7 @@ export default class ResponseService extends PercyClientService {
     }
 
     // Capture if the resourceUrl has a hostname in the allowedHostnames
-    const parsedResourceUrl = new URL(resourceUrl)
-    if (this.allowedHostnames.some((hostname) => parsedResourceUrl.hostname === hostname)) {
+    if (this.allowedHostnames.some((hostname) => domainMatch(hostname, resourceUrl))) {
       return true
     }
 

--- a/src/utils/domain-match.ts
+++ b/src/utils/domain-match.ts
@@ -1,0 +1,41 @@
+import { URL } from 'url'
+
+function domainCheck(domain: string, host: string, isWild: boolean) {
+  if (domain === host) {
+    return true
+  }
+
+  if (isWild && host) {
+    const last = host.lastIndexOf(domain)
+    return (last >= 0 && ((last + domain.length) === host.length))
+  }
+
+  return false
+}
+
+function pathCheck(pathprefix: string, pathname: string) {
+  return pathname.indexOf(pathprefix) === 0
+}
+
+export default function domainMatch(pattern: string, siteUrl: string) {
+  if (pattern === '*') {
+    return true
+  } else if (!pattern) {
+    return false
+  }
+
+  const isWild = ((pattern.indexOf('*.') === 0) || (pattern.indexOf('*/') === 0))
+
+  // tslint:disable-next-line
+  let slashed = pattern.split('/') // tslint wants this to be `const` even though it's mutated
+  let domain = slashed.shift() as string
+
+  const pathprefix = `/${slashed.join('/')}`
+  const parsedUrl = new URL(siteUrl)
+
+  if (isWild) {
+    domain = domain.substr(2)
+  }
+
+  return (domainCheck(domain, parsedUrl.hostname, isWild) && pathCheck(pathprefix, parsedUrl.pathname))
+}


### PR DESCRIPTION
## Purpose

When the subdomain of a hostname is variable, not known, or has many other subdomains, it is more concise to use a wildcard subdomain.

## Approach

Attempted to use [`domainMatch`](https://www.npmjs.com/package/domain-match) to compare the resource hostname with the allowed hostnames. However internally, the package uses `parsedURL.host` which contains the port number and causes the check to fail. [The source code](https://github.com/palanik/domain-match/blob/master/index.js) was fairly small and straightforward, so I copied it here and adjusted it to use `hostname` which does not contain the port number.

Copying the small util here also made typescript happy about missing type defs.