### PR TITLE
fix: Concat hostname option from CLI & config file

### DIFF
--- a/src/services/configuration-service.ts
+++ b/src/services/configuration-service.ts
@@ -40,7 +40,8 @@ export default class ConfigurationService {
     }
 
     if (flags['allowed-hostname']) {
-      this.configuration.agent['asset-discovery']['allowed-hostnames'] = flags['allowed-hostname']
+      this.configuration.agent['asset-discovery']['allowed-hostnames'] =
+        flags['allowed-hostname'].concat(this.configuration.agent['asset-discovery']['allowed-hostnames'])
     }
 
     if (flags['network-idle-timeout']) {

--- a/test/services/configuration-service.test.ts
+++ b/test/services/configuration-service.test.ts
@@ -52,9 +52,8 @@ describe('ConfigurationService', () => {
       expect(subject['static-snapshots']['snapshot-files']).to.eql('flags/*.html')
       expect(subject['static-snapshots']['ignore-files']).to.eql('ignore-flags/*.html')
       expect(subject.agent['asset-discovery']['network-idle-timeout']).to.eql(51)
-      expect(subject.agent['asset-discovery']['allowed-hostnames']).to.eql(
-        ['additional-hostname.local'],
-      )
+      expect(subject.agent['asset-discovery']['allowed-hostnames'][1]).to.eql('localassets.dev')
+      expect(subject.agent['asset-discovery']['allowed-hostnames'][0]).to.eql('additional-hostname.local')
     })
   })
 

--- a/test/services/configuration-service.test.ts
+++ b/test/services/configuration-service.test.ts
@@ -38,7 +38,7 @@ describe('ConfigurationService', () => {
   })
 
   describe('#applyFlags', () => {
-    it('applies flags', () => {
+    it('applies flags with a .percy.yml', () => {
       const flags = {
         'network-idle-timeout': 51,
         'base-url': '/flag/',
@@ -53,6 +53,23 @@ describe('ConfigurationService', () => {
       expect(subject['static-snapshots']['ignore-files']).to.eql('ignore-flags/*.html')
       expect(subject.agent['asset-discovery']['network-idle-timeout']).to.eql(51)
       expect(subject.agent['asset-discovery']['allowed-hostnames'][1]).to.eql('localassets.dev')
+      expect(subject.agent['asset-discovery']['allowed-hostnames'][0]).to.eql('additional-hostname.local')
+    })
+
+    it('applies flags without a .percy.yml', () => {
+      const flags = {
+        'network-idle-timeout': 51,
+        'base-url': '/flag/',
+        'snapshot-files': 'flags/*.html',
+        'ignore-files': 'ignore-flags/*.html',
+        'allowed-hostname': ['additional-hostname.local'],
+      }
+      const subject = new ConfigurationService('test/support/doesnt-exist/.percy.yml').applyFlags(flags)
+
+      expect(subject['static-snapshots']['base-url']).to.eql('/flag/')
+      expect(subject['static-snapshots']['snapshot-files']).to.eql('flags/*.html')
+      expect(subject['static-snapshots']['ignore-files']).to.eql('ignore-flags/*.html')
+      expect(subject.agent['asset-discovery']['network-idle-timeout']).to.eql(51)
       expect(subject.agent['asset-discovery']['allowed-hostnames'][0]).to.eql('additional-hostname.local')
     })
   })


### PR DESCRIPTION
## What is this?

This PR makes it so you can pass an `-h` flag, and that'll get applied _along_ with the
hostnames specified in the `.percy.yml`. 