### PR TITLE
feat: Capture redirected assets 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cross-spawn": "^6.0.5",
     "deepmerge": "^4.0.0",
     "express": "^4.16.3",
+    "follow-redirects": "^1.9.0",
     "generic-pool": "^3.7.1",
     "globby": "^10.0.1",
     "js-yaml": "^3.13.1",

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -80,7 +80,7 @@ export default class ResponseService extends PercyClientService {
     if (isRedirect) {
       // We don't want to follow too deep of a chain
       // `followRedirects` is the npm package axios uses to follow redirected requests
-      // we'll use their max redirect setting as a gaurd here
+      // we'll use their max redirect setting as a guard here
       if (request.redirectChain().length > followRedirects.maxRedirects) {
         logger.debug(`Skipping [redirect_too_deep: ${request.redirectChain().length}] [${width} px]: ${response.url()}`)
         return

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -98,7 +98,6 @@ export default class ResponseService extends PercyClientService {
    * will download the resource from node, and save the content as the orignal
    * requesting url. This works since axios follows the redirect chain
    * automatically.
-   *
    */
   async handleRedirectResouce(originalURL: string, redirectedURL: string, width: number, logger: any) {
     logger.debug(`Making local copy of redirected response: ${originalURL}`)
@@ -119,9 +118,9 @@ export default class ResponseService extends PercyClientService {
       return
     }
 
-    // By not setting contentType, it serves it correctly in our proxy
     const contentType = headers['content-type'] as string
     const resource = this.resourceService.createResourceFromFile(originalURL, localCopy, contentType, logger)
+
     this.responsesProcessed.set(originalURL, resource)
     this.responsesProcessed.set(redirectedURL, resource)
 
@@ -131,7 +130,6 @@ export default class ResponseService extends PercyClientService {
   /**
    * Handle processing and saving a resource coming from Puppeteer. This will
    * take the response object from Puppeteer and save the asset locally.
-   *
    */
   async handlePuppeteerResource(url: string, response: puppeteer.Response, width: number, logger: any) {
     logger.debug(`Making local copy of response: ${response.url()}`)
@@ -162,7 +160,6 @@ export default class ResponseService extends PercyClientService {
   /**
    * Write a local copy of the SHA only if it doesn't exist on the file system
    * already.
-   *
    */
   maybeWriteFile(filePath: string, buffer: any): boolean {
     if (!fs.existsSync(filePath)) {
@@ -176,7 +173,6 @@ export default class ResponseService extends PercyClientService {
   /**
    * Ensures the saved file is not larger than what the Percy API accepts. It
    * returns if the file is too large, as well as the files size.
-   *
    */
   checkFileSize(filePath: string) {
     const responseBodySize = fs.statSync(filePath).size

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -98,8 +98,8 @@ export default class ResponseService extends PercyClientService {
   async handleRedirectResouce(redirectedURL: string, response: puppeteer.Response, width: number, logger: any) {
     logger.debug(`Making local copy of redirected response: ${redirectedURL}`)
 
-    const { data } = await Axios(redirectedURL, { responseType: 'text' }) as any
-    const buffer = Buffer.from(data, 'utf8')
+    const { data, headers } = await Axios(redirectedURL, { responseType: 'arraybuffer' }) as any
+    const buffer = Buffer.from(data)
     const sha = crypto.createHash('sha256').update(buffer).digest('hex')
     const localCopy = path.join(os.tmpdir(), sha)
     const didWriteFile = this.maybeWriteFile(localCopy, buffer)
@@ -115,7 +115,8 @@ export default class ResponseService extends PercyClientService {
     }
 
     // By not setting contentType, it serves it correctly in our proxy
-    const resource = this.resourceService.createResourceFromFile(redirectedURL, localCopy, '', logger)
+    const contentType = headers['content-type'] as string
+    const resource = this.resourceService.createResourceFromFile(redirectedURL, localCopy, contentType, logger)
     this.responsesProcessed.set(redirectedURL, resource)
 
     return resource

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -10,11 +10,11 @@ import Constants from './constants'
 import PercyClientService from './percy-client-service'
 import ResourceService from './resource-service'
 
+const REDIRECT_STATUSES = [301, 302, 304, 307, 308]
+const ALLOWED_RESPONSE_STATUSES = [200, 201, ...REDIRECT_STATUSES]
+
 export default class ResponseService extends PercyClientService {
   resourceService: ResourceService
-
-  readonly REDIRECT_STATUSES = [301, 302, 304, 307, 308]
-  readonly ALLOWED_RESPONSE_STATUSES = [200, 201, 301, 302, 304, 307, 308]
   responsesProcessed: Map<string, string> = new Map()
   allowedHostnames: string[]
 
@@ -54,7 +54,7 @@ export default class ResponseService extends PercyClientService {
 
     const request = response.request()
     const parsedRootResourceUrl = new URL(rootResourceUrl)
-    const isRedirect = this.REDIRECT_STATUSES.includes(response.status())
+    const isRedirect = REDIRECT_STATUSES.includes(response.status())
     const rootUrl = `${parsedRootResourceUrl.protocol}//${parsedRootResourceUrl.host}`
 
     if (request.url() === rootResourceUrl) {
@@ -63,7 +63,7 @@ export default class ResponseService extends PercyClientService {
       return
     }
 
-    if (!this.ALLOWED_RESPONSE_STATUSES.includes(response.status())) {
+    if (!ALLOWED_RESPONSE_STATUSES.includes(response.status())) {
       // Only allow 2XX responses:
       logger.debug(`Skipping [disallowed_response_status_${response.status()}] [${width} px]: ${response.url()}`)
       return

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -90,9 +90,10 @@ describe('Integration test', () => {
 
     it('snapshots a site with redirected assets', async () => {
       await page.goto('https://kind-goldstine-64b202.netlify.com/redirects/')
+      await page.waitFor('.note')
       const domSnapshot = await snapshot(page, 'Redirects snapshot')
 
-      expect(domSnapshot).contains('redirected resource')
+      expect(domSnapshot).contains('correctly snapshotted')
     })
 
   })

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -89,7 +89,7 @@ describe('Integration test', () => {
     })
 
     it('snapshots a site with redirected assets', async () => {
-      await page.goto('https://kind-goldstine-64b202.netlify.com/redirects/')
+      await page.goto('https://sdk-test.percy.dev/redirects/')
       await page.waitFor('.note')
       const domSnapshot = await snapshot(page, 'Redirects snapshot')
 

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -88,6 +88,13 @@ describe('Integration test', () => {
       expect(domSnapshot).contains('Buildkite')
     })
 
+    it('snapshots a site with redirected assets', async () => {
+      await page.goto('https://kind-goldstine-64b202.netlify.com/redirects/')
+      const domSnapshot = await snapshot(page, 'Redirects snapshot')
+
+      expect(domSnapshot).contains('redirected resource')
+    })
+
   })
 
   describe('on local test cases', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3217,7 +3217,7 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.1.0, debug@^3.2.6:
+debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4338,6 +4338,13 @@ follow-redirects@^1.0.0:
   integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
   dependencies:
     debug "^3.2.6"
+
+follow-redirects@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
+  integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
+  dependencies:
+    debug "^3.0.0"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## What is this? 

This PR introduces the ability to capture assets that are discovered, but have a redirect chain. Currently agent will skip these assets since it's not super easy to follow the chain all the way through and then capture that asset in Puppeteer.

## Approach

The redirected resources are captured by requesting the redirected URL with `axios` from Node. This will properly follow the redirect chain for us, then we save the response body of that request as the original request URL (so it proxy's correctly in our rendering env).

While doing this I refactored the methods for capturing resources to their respective paths now. Normal assets from the asset discovery service using puppeteer now process their resource and redirected resources are not processed via Node. 

## TODOs

- [x] Update the test SDK site with the redirect resource test in this PR (https://github.com/percy/sdk-test-website/pull/1)
- [x] `feat` or `fix`?