### PR TITLE
build: Correct `follow-redirects` dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cross-spawn": "^6.0.5",
     "deepmerge": "^4.0.0",
     "express": "^4.16.3",
-    "follow-redirects": "^1.9.0",
+    "follow-redirects": "1.5.10",
     "generic-pool": "^3.7.1",
     "globby": "^10.0.1",
     "image-size": "^0.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4319,13 +4319,6 @@ follow-redirects@1.5.10:
     debug "=3.1.0"
 
 follow-redirects@^1.0.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
-  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
-  dependencies:
-    debug "^3.2.6"
-
-follow-redirects@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
   integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==


### PR DESCRIPTION
## What is this?

This is so we're not depending on a newer version of `follow-redirects` than `axios` is. Now the same version of `follow-redirects` that axios uses is imported into our code (https://github.com/axios/axios/blob/v0.18.1/package.json#L74)

I don't think we need to release for this. It can go out with the next version 👍 

<img width="460" alt="image" src="https://user-images.githubusercontent.com/2072894/65285089-0cefc080-db01-11e9-9f67-129d7349ea27.png">
