### PR TITLE
fix: Check for widths array length so empty arrays are never used

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -96,9 +96,10 @@ export class AgentService {
     const configuration = new ConfigurationService().configuration
     // trim the string of whitespace and concat per-snapshot CSS with the globally specified CSS
     const percySpecificCSS = configuration.snapshot['percy-css'].concat(request.body.percyCSS || '').trim()
+    const hasWidths = !!request.body.widths && request.body.widths.length
     const snapshotOptions: SnapshotOptions = {
       percyCSS: percySpecificCSS,
-      widths: request.body.widths || configuration.snapshot.widths,
+      widths: hasWidths ? request.body.widths : configuration.snapshot.widths,
       enableJavaScript: request.body.enableJavaScript != null
         ? request.body.enableJavaScript
         : configuration.snapshot['enable-javascript'],

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -96,6 +96,12 @@ describe('Integration test', () => {
       expect(domSnapshot).contains('correctly snapshotted')
     })
 
+    it('falls back to default widths when nothing is passed', async () => {
+      await page.goto('https://sdk-test.percy.dev/')
+
+      await snapshot(page, 'Empty widths array', { widths: [] })
+    })
+
   })
 
   describe('on local test cases', () => {


### PR DESCRIPTION
## What is this?

If you pass an empty array from and SDK, the asset discovery service blows up. We should just fall back to the default widths