### PR TITLE
fix: Add Percy specific CSS to root resource after asset discovery

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -128,9 +128,9 @@ export class AgentService {
     )
 
     resources = resources.concat(
-      this.snapshotService.buildLogResource(snapshotLog),
       // @ts-ignore we won't write anything if css is not is passed
-      this.snapshotService.buildPercyCSSResource(percyCSSFileName, snapshotOptions.percyCSS),
+      this.snapshotService.buildPercyCSSResource(percyCSSFileName, snapshotOptions.percyCSS, snapshotLogger),
+      this.snapshotService.buildLogResource(snapshotLog),
     )
 
     const snapshotCreation = this.snapshotService.create(

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -106,7 +106,7 @@ export class AgentService {
       minHeight: request.body.minHeight || configuration.snapshot['min-height'],
     }
 
-    const domSnapshot = request.body.domSnapshot
+    let domSnapshot = request.body.domSnapshot
 
     if (domSnapshot.length > Constants.MAX_FILE_SIZE_BYTES) {
       logger.info(`snapshot skipped[max_file_size_exceeded]: '${request.body.name}'`)
@@ -127,10 +127,11 @@ export class AgentService {
     // serving a response for this CSS we're injecting into the DOM
     if (snapshotOptions.percyCSS) {
       const cssLink = `<link data-percy-specific-css rel="stylesheet" href="/${percyCSSFileName}" />`
-      resources[0].content = resources[0].content.replace(/<\/body>/i, cssLink + '$&')
+      domSnapshot = domSnapshot.replace(/<\/body>/i, cssLink + '$&')
     }
 
     resources = resources.concat(
+      this.snapshotService.buildRootResource(request.body.url, domSnapshot),
       // @ts-ignore we won't write anything if css is not is passed
       this.snapshotService.buildPercyCSSResource(percyCSSFileName, snapshotOptions.percyCSS, snapshotLogger),
       this.snapshotService.buildLogResource(snapshotLog),

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -23,27 +23,27 @@ export default class SnapshotService extends PercyClientService {
     this.assetDiscoveryService = new AssetDiscoveryService(buildId, configuration)
   }
 
-  async buildResources(
+  buildResources(
     rootResourceUrl: string,
     domSnapshot = '',
     options: SnapshotOptions,
     logger: any,
   ): Promise<any[]> {
-    const rootResource = this.percyClient.makeResource({
-      resourceUrl: rootResourceUrl,
-      content: domSnapshot,
-      isRoot: true,
-      mimetype: 'text/html',
-    })
-
-    const discoveredResources = await this.assetDiscoveryService.discoverResources(
+    return this.assetDiscoveryService.discoverResources(
       rootResourceUrl,
       domSnapshot,
       options,
       logger,
     )
+  }
 
-    return [rootResource].concat(discoveredResources)
+  buildRootResource(rootResourceUrl: string, domSnapshot = ''): Promise<any[]> {
+    return this.percyClient.makeResource({
+      resourceUrl: rootResourceUrl,
+      content: domSnapshot,
+      isRoot: true,
+      mimetype: 'text/html',
+    })
   }
 
   buildLogResource(logFilePath: string) {

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -65,8 +65,10 @@ export default class SnapshotService extends PercyClientService {
     })
   }
 
-  buildPercyCSSResource(fileName: string, css: string) {
+  buildPercyCSSResource(fileName: string, css: string, logger: any) {
     if (!css) { return [] }
+    logger.debug(`Creating Percy Specific file: ${fileName}. CSS string: ${css}`)
+
     const buffer = Buffer.from(css, 'utf8')
     const sha = crypto.createHash('sha256').update(buffer).digest('hex')
     const localPath = path.join(os.tmpdir(), sha)
@@ -74,6 +76,8 @@ export default class SnapshotService extends PercyClientService {
     // write the SHA file if it doesn't exist
     if (!fs.existsSync(localPath)) {
       fs.writeFileSync(localPath, buffer, 'utf8')
+    } else {
+      logger.debug(`Skipping writing Percy specific file: ${fileName}.`)
     }
 
     return this.percyClient.makeResource({


### PR DESCRIPTION
## What is this?

While debugging some percy CSS weirdness I thought it would be pretty nice to see in the logs when this is created and if its skipped, why? 