### PR TITLE
fix: Handle 404 errors when capturing redirected assets

### DIFF
--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -102,29 +102,37 @@ export default class ResponseService extends PercyClientService {
   async handleRedirectResouce(originalURL: string, redirectedURL: string, width: number, logger: any) {
     logger.debug(`Making local copy of redirected response: ${originalURL}`)
 
-    const { data, headers } = await Axios(originalURL, { responseType: 'arraybuffer' }) as any
-    const buffer = Buffer.from(data)
-    const sha = crypto.createHash('sha256').update(buffer).digest('hex')
-    const localCopy = path.join(os.tmpdir(), sha)
-    const didWriteFile = this.maybeWriteFile(localCopy, buffer)
-    const { fileIsTooLarge, responseBodySize } = this.checkFileSize(localCopy)
+    try {
 
-    if (!didWriteFile) {
-      logger.debug(`Skipping file copy [already_copied]: ${originalURL}`)
-    }
+      const response = await Axios(originalURL, { responseType: 'arraybuffer' }) as any
+      const buffer = Buffer.from(response.data)
+      const sha = crypto.createHash('sha256').update(buffer).digest('hex')
+      const localCopy = path.join(os.tmpdir(), sha)
+      const didWriteFile = this.maybeWriteFile(localCopy, buffer)
+      const { fileIsTooLarge, responseBodySize } = this.checkFileSize(localCopy)
 
-    if (fileIsTooLarge) {
-      logger.debug(`Skipping [max_file_size_exceeded_${responseBodySize}] [${width} px]: ${originalURL}`)
+      if (!didWriteFile) {
+        logger.debug(`Skipping file copy [already_copied]: ${originalURL}`)
+      }
+
+      if (fileIsTooLarge) {
+        logger.debug(`Skipping [max_file_size_exceeded_${responseBodySize}] [${width} px]: ${originalURL}`)
+        return
+      }
+
+      const contentType = response.headers['content-type'] as string
+      const resource = this.resourceService.createResourceFromFile(originalURL, localCopy, contentType, logger)
+
+      this.responsesProcessed.set(originalURL, resource)
+      this.responsesProcessed.set(redirectedURL, resource)
+
+      return resource
+    } catch (err) {
+      logger.debug(`${err}`)
+      logger.debug(`Failed to make a local copy of redirected response: ${originalURL}`)
+
       return
     }
-
-    const contentType = headers['content-type'] as string
-    const resource = this.resourceService.createResourceFromFile(originalURL, localCopy, contentType, logger)
-
-    this.responsesProcessed.set(originalURL, resource)
-    this.responsesProcessed.set(redirectedURL, resource)
-
-    return resource
   }
 
   /**

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -103,9 +103,8 @@ export default class ResponseService extends PercyClientService {
     logger.debug(`Making local copy of redirected response: ${originalURL}`)
 
     try {
-
-      const response = await Axios(originalURL, { responseType: 'arraybuffer' }) as any
-      const buffer = Buffer.from(response.data)
+      const { data, headers } = await Axios(originalURL, { responseType: 'arraybuffer' }) as any
+      const buffer = Buffer.from(data)
       const sha = crypto.createHash('sha256').update(buffer).digest('hex')
       const localCopy = path.join(os.tmpdir(), sha)
       const didWriteFile = this.maybeWriteFile(localCopy, buffer)
@@ -120,7 +119,7 @@ export default class ResponseService extends PercyClientService {
         return
       }
 
-      const contentType = response.headers['content-type'] as string
+      const contentType = headers['content-type'] as string
       const resource = this.resourceService.createResourceFromFile(originalURL, localCopy, contentType, logger)
 
       this.responsesProcessed.set(originalURL, resource)

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -90,10 +90,11 @@ describe('Integration test', () => {
 
     it('snapshots a site with redirected assets', async () => {
       await page.goto('https://sdk-test.percy.dev/redirects/')
-      await page.waitFor('.note')
+      await page.waitFor('h2')
       const domSnapshot = await snapshot(page, 'Redirects snapshot')
 
-      expect(domSnapshot).contains('correctly snapshotted')
+      // This will fail the test if the redirected JS fails to work
+      expect(domSnapshot).contains('Snapshot worked')
     })
 
     it('falls back to default widths when nothing is passed', async () => {


### PR DESCRIPTION
## What is this?

Turns out redirected assets that 404 can break asset discovery, who knew? :trollface: 😆 

This PR wraps the network call in try/catch (like it always should have been) and handles redirected assets that 404 properly now. 