### PR TITLE
fix: Capture assets using the same hostname, regardless of port

### DIFF
--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -57,7 +57,7 @@ export default class ResponseService extends PercyClientService {
     const request = response.request()
     const parsedRootResourceUrl = new URL(rootResourceUrl)
     const isRedirect = REDIRECT_STATUSES.includes(response.status())
-    const rootUrl = `${parsedRootResourceUrl.protocol}//${parsedRootResourceUrl.host}`
+    const rootUrl = `${parsedRootResourceUrl.protocol}//${parsedRootResourceUrl.hostname}`
 
     if (request.url() === rootResourceUrl) {
       // Always skip the root resource


### PR DESCRIPTION
## What is this?

Currently, if someone is serving their app from `localhost:3001` and then serves their assets from `localhost:3002`, we will skip the assets coming from `localhost:3002`. This is because we're taking the port into account for asset discovery right now.

This change removes the port from consideration and captures all assets based on the `hostname` rather than `host`.


## TODO

- [ ] Verify this doesn't break proxying in weird cases. 