### PR TITLE
fix: Cleanup on stopping agent

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -52,5 +52,9 @@ export default class Exec extends PercyCommand {
     // Even if Percy will not run, continue to run the subprocess
     const spawnedProcess = spawn(command, argv, { stdio: 'inherit' })
     spawnedProcess.on('exit', (code) => this.stop(code))
+    spawnedProcess.on('error', (error) => {
+      this.logger.error(error)
+      this.stop(1)
+    })
   }
 }

--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -84,8 +84,8 @@ export default class Snapshot extends PercyCommand {
       this.exit(1)
     }
 
-    await this.agentService.start(configuration)
-    this.logStart()
+    // start agent service and attach process handlers
+    await this.start(flags)
 
     const staticSnapshotService = new StaticSnapshotService(configuration['static-snapshots'])
 
@@ -97,6 +97,6 @@ export default class Snapshot extends PercyCommand {
 
      // stop the static snapshot and agent services
     await staticSnapshotService.stop()
-    await this.agentService.stop()
+    await this.stop()
   }
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -53,6 +53,11 @@ export default class Start extends PercyCommand {
     await healthCheck(flags.port!)
   }
 
+  async stop(exitCode?: any) {
+    this.processService.cleanup()
+    await super.stop(exitCode)
+  }
+
   private runDetached(flags: any) {
     const pid = this.processService.runDetached([
       path.resolve(`${__dirname}/../../bin/run`),

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -42,51 +42,24 @@ export default class Start extends PercyCommand {
     // If Percy is disabled or is missing a token, gracefully exit here
     if (!this.percyWillRun()) { this.exit(0) }
 
-    const {flags} = this.parse(Start)
+    const { flags } = this.parse(Start)
 
     if (flags.detached) {
-      this.runDetached()
+      this.runDetached(flags)
     } else {
-      await this.runAttached()
+      await this.start(flags)
     }
 
     await healthCheck(flags.port!)
   }
 
-  private async runAttached() {
-    const {flags} = this.parse(Start)
-
-    process.on('SIGHUP', async () => {
-      await this.agentService.stop()
-      process.exit(0)
-    })
-
-    process.on('SIGINT', async () => {
-      await this.agentService.stop()
-      process.exit(0)
-    })
-
-    process.on('SIGTERM', async () => {
-      await this.agentService.stop()
-      process.exit(0)
-    })
-
-    const configuration = new ConfigurationService().applyFlags(flags)
-    await this.agentService.start(configuration)
-    this.logStart()
-  }
-
-  private runDetached() {
-    const {flags} = this.parse(Start)
-
-    const pid = this.processService.runDetached(
-      [
-        path.resolve(`${__dirname}/../../bin/run`),
-        'start',
-        '-p', String(flags.port!),
-        '-t', String(flags['network-idle-timeout']),
-      ],
-    )
+  private runDetached(flags: any) {
+    const pid = this.processService.runDetached([
+      path.resolve(`${__dirname}/../../bin/run`),
+      'start',
+      '-p', String(flags.port!),
+      '-t', String(flags['network-idle-timeout']),
+    ])
 
     if (pid) {
       this.logStart()

--- a/src/services/process-service.ts
+++ b/src/services/process-service.ts
@@ -33,9 +33,18 @@ export default class ProcessService {
   kill() {
     if (this.isRunning()) {
       const pid = this.getPid()
-      fs.unlinkSync(ProcessService.PID_PATH)
+      this.cleanup()
 
       process.kill(pid, 'SIGHUP')
+    }
+  }
+
+  cleanup() {
+    try {
+      fs.unlinkSync(ProcessService.PID_PATH)
+    } catch (e) {
+      // it's fine when the file doesn't exist, raise errors otherwise
+      if (e.code !== 'ENOENT') { throw e }
     }
   }
 


### PR DESCRIPTION
## Purpose

This started out as a fix for #340, to ensure that when agent is terminated, the PID file is always cleaned up. The approach made it easy to preemptively fix a couple of other bugs as well.

## Approach

The `start` and `exec` commands shared similar startup behavior, but `exec` had better stop behavior by ensuring it is only ever stopped once (due to multiple events). The better behavior from the `exec` command was DRY'd up and moved into the base `PercyCommand` class.

We can then take advantage of inheritance to clean up the PID file whenever the new `stop` method is called. This created an error when the PID file was already cleaned up, so I split up the existing logic to suppress file-not-found errors.

The common `start` and `stop` methods made it possible for the static snapshot command to also gracefully stop the server upon receiving termination events.

Since it seemed relevant, I added a missing child process `error` handler as per #381. According to [Node docs](https://nodejs.org/api/child_process.html#child_process_event_error), it should only be triggered when the child process can not be spawned or killed.