### PR TITLE
fix: Restrict try-catch in upload command so build can be finalized

### DIFF
--- a/src/services/image-snapshot-service.ts
+++ b/src/services/image-snapshot-service.ts
@@ -105,21 +105,21 @@ export default class ImageSnapshotService extends PercyClientService {
   }
 
   async snapshotAll() {
+    // intentially remove '' values from because that matches every file
+    const globs = this.configuration.files.split(',').filter(Boolean)
+    const ignore = this.configuration.ignore.split(',').filter(Boolean)
+    const paths = await globby(globs, { cwd: this.configuration.path, ignore })
+
+    if (!paths.length) {
+      logger.error(`no matching files found in '${this.configuration.path}''`)
+      logger.info('exiting')
+      return process.exit(1)
+    }
+
+    await this.buildService.create()
+    logger.debug('uploading snapshots of static images')
+
     try {
-      // intentially remove '' values from because that matches every file
-      const globs = this.configuration.files.split(',').filter(Boolean)
-      const ignore = this.configuration.ignore.split(',').filter(Boolean)
-      const paths = await globby(globs, { cwd: this.configuration.path, ignore })
-
-      if (!paths.length) {
-        logger.error(`no matching files found in '${this.configuration.path}''`)
-        logger.info('exiting')
-        return process.exit(1)
-      }
-
-      await this.buildService.create()
-      logger.debug('uploading snapshots of static images')
-
       // wait for snapshots in parallel
       await Promise.all(paths.reduce((promises, pathname) => {
         logger.debug(`handling snapshot: '${pathname}'`)
@@ -140,12 +140,11 @@ export default class ImageSnapshotService extends PercyClientService {
 
         return promises
       }, [] as any[]))
-
-      // finalize build
-      await this.buildService.finalize()
     } catch (error) {
       logError(error)
-      process.exit(1)
     }
+
+    // finalize build
+    await this.buildService.finalize()
   }
 }

--- a/src/services/image-snapshot-service.ts
+++ b/src/services/image-snapshot-service.ts
@@ -109,6 +109,7 @@ export default class ImageSnapshotService extends PercyClientService {
     const globs = this.configuration.files.split(',').filter(Boolean)
     const ignore = this.configuration.ignore.split(',').filter(Boolean)
     const paths = await globby(globs, { cwd: this.configuration.path, ignore })
+    let error
 
     if (!paths.length) {
       logger.error(`no matching files found in '${this.configuration.path}''`)
@@ -140,11 +141,15 @@ export default class ImageSnapshotService extends PercyClientService {
 
         return promises
       }, [] as any[]))
-    } catch (error) {
-      logError(error)
+    } catch (err) {
+      error = err
+      logError(err)
     }
 
     // finalize build
     await this.buildService.finalize()
+
+    // if an error occurred, exit with non-zero
+    if (error) process.exit(1)
   }
 }


### PR DESCRIPTION
## Purpose

During image upload, If an error occurs after starting a build, but before finalizing, the build will get stuck waiting for snapshots.

## Approach

Rather than try-catching the entire method, the try-catch can be wrapped around only the section between creating and finalizing a build. The try-catch is used instead of chaining a `.catch` onto the promise in case the `reduce` callback throws during argument evaluation.