### PR TITLE
fix: Config array merging

### DIFF
--- a/.ci.percy.yml
+++ b/.ci.percy.yml
@@ -1,5 +1,6 @@
 version: 1
 snapshot:
+  widths: [375, 1200]
   percy-css: |
     .percy-only-css-global {
       height: 300px;

--- a/src/services/image-snapshot-service.ts
+++ b/src/services/image-snapshot-service.ts
@@ -150,6 +150,6 @@ export default class ImageSnapshotService extends PercyClientService {
     await this.buildService.finalize()
 
     // if an error occurred, exit with non-zero
-    if (error) process.exit(1)
+    if (error) { process.exit(1) }
   }
 }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -81,5 +81,9 @@ export default function config({ config, ...flags }: any, args: any = {}) {
     logger.debug(`Using config: ${inspect(overrides, { depth: null })}`)
   }
 
-  return merge.all([DEFAULT_CONFIGURATION, overrides].filter(Boolean)) as Configuration
+  return merge.all(
+    [DEFAULT_CONFIGURATION, overrides].filter(Boolean),
+    // overwrite default arrays, do not merge
+    { arrayMerge: (_, arr) => arr },
+  ) as Configuration
 }


### PR DESCRIPTION
## Purpose

By default, the `deepmerge` package will merge nested arrays. When merging default options with overrides, this had the effect of merging default widths with user-defined widths.

## Approach

Pass an `arrayMerge` option that will overwrite default arrays with new arrays instead of merging them.

Added a `widths` option to our test config to verify that we should only see `375` and `1200` widths and _not also_ default `1280` widths. Due to this, all of our snapshots have a new width that needs to be approved.