### PR TITLE
feat: :sparkles: Add client info for upload command

### DIFF
--- a/src/services/image-snapshot-service.ts
+++ b/src/services/image-snapshot-service.ts
@@ -92,6 +92,7 @@ export default class ImageSnapshotService extends PercyClientService {
       name,
       widths: [width],
       minimumHeight: height,
+      clientInfo: 'percy-upload',
     }).then(async (response: any) => {
       await this.percyClient.uploadMissingResources(this.buildId, response, resources)
       return response


### PR DESCRIPTION
Adds to the environment info section for builds when the upload command is used.

![image](https://user-images.githubusercontent.com/5005153/66502182-673dca80-ea8a-11e9-8f32-8b22979af6b6.png)
