### PR TITLE
ci: Refactor CI & Combine Percy builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,6 @@ jobs:
           name: Integration tests
           command: $NYC yarn test-integration
       - run:
-          name: Finalize Percy
-          command: ./bin/run finalize --all
-      - run:
           name: Gather reports
           command: $NYC report --reporter text-lcov > coverage.lcov
       - store_test_results: &store_test_results
@@ -59,6 +56,10 @@ jobs:
     <<: *test
     docker:
       - image: circleci/node:8-browsers
+  finalize_percy:
+    <<: *test
+    steps:
+      - run: ./bin/run finalize --all
   release:
     <<: *test
     steps:
@@ -72,6 +73,10 @@ workflows:
     jobs:
       - node-10
       - node-8
+      - finalize_percy:
+          requires:
+          - node-10
+          - node-8
       - release:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,19 @@ commands:
       - run:
           name: Build package
           command: yarn build
-  store_artifacts:
+  unit_client_integration:
     steps:
       - run:
-          name: Gather reports
-          command: $NYC report --reporter text-lcov > coverage.lcov
-      - store_test_results: &store_test_results
-          path: ~/cli/reports
+          name: Unit tests
+          command: |
+            mkdir -p reports
+            $NYC yarn test --reporter mocha-junit-reporter
+      - run:
+          name: Client tests
+          command: $NYC yarn test-client --singleRun
+      - run:
+          name: Integration tests
+          command: $NYC yarn test-integration
   cli_integration:
     steps:
       - run:
@@ -46,6 +52,13 @@ commands:
       - run:
           name: Help command
           command: ./bin/run --help
+  store_artifacts:
+    steps:
+      - run:
+          name: Gather reports
+          command: $NYC report --reporter text-lcov > coverage.lcov
+      - store_test_results: &store_test_results
+          path: ~/cli/reports
 
 version: 2.1
 jobs:
@@ -56,17 +69,7 @@ jobs:
     steps:
       - setup
       - cli_commands
-      - run:
-          name: Unit tests
-          command: |
-            mkdir -p reports
-            $NYC yarn test --reporter mocha-junit-reporter
-      - run:
-          name: Client tests
-          command: $NYC yarn test-client --singleRun
-      - run:
-          name: Integration tests
-          command: $NYC yarn test-integration
+      - unit_client_integration
       - run:
           name: Disable Percy for CLI integration tests
           command: export PERCY_ENABLE=0
@@ -79,17 +82,7 @@ jobs:
     steps:
       - setup
       - cli_commands
-      - run:
-          name: Unit tests
-          command: |
-            mkdir -p reports
-            $NYC yarn test --reporter mocha-junit-reporter
-      - run:
-          name: Client tests
-          command: $NYC yarn test-client --singleRun
-      - run:
-          name: Integration tests
-          command: $NYC yarn test-integration
+      - unit_client_integration
       - cli_integration
       - store_artifacts
   finalize_percy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ jobs:
   finalize_percy:
     <<: *test
     steps:
+      - checkout
+      - run: yarn && yarn build
       - run: ./bin/run finalize --all
   release:
     <<: *test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     environment:
       NYC: "yarn exec nyc -- --nycrc-path node_modules/@oclif/nyc-config/.nycrc"
       MOCHA_FILE: "reports/mocha.xml"
+      PERCY_PARALLEL_TOTAL: "-1"
     steps:
       - checkout
       - restore_cache: &restore_cache
@@ -46,6 +47,9 @@ jobs:
       - run:
           name: Integration tests
           command: $NYC yarn test-integration
+      - run:
+          name: Finalize Percy
+          command: ./bin/run finalize --all
       - run:
           name: Gather reports
           command: $NYC report --reporter text-lcov > coverage.lcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 ---
-version: 2
-jobs:
-  node-10: &test
-    docker:
-      - image: circleci/node:10-browsers
+references:
+  test_config: &test_config
     working_directory: ~/cli
     environment:
       NYC: "yarn exec nyc -- --nycrc-path node_modules/@oclif/nyc-config/.nycrc"
       MOCHA_FILE: "reports/mocha.xml"
       PERCY_PARALLEL_TOTAL: "-1"
+
+commands:
+  setup:
     steps:
       - checkout
       - restore_cache: &restore_cache
@@ -21,14 +21,41 @@ jobs:
           name: Install CI only dependencies
           command: yarn add -D --no-lockfile nyc@11 @oclif/nyc-config@1 mocha-junit-reporter@1
       - run:
+          name: Build package
+          command: yarn build
+  store_artifacts:
+    steps:
+      - run:
+          name: Gather reports
+          command: $NYC report --reporter text-lcov > coverage.lcov
+      - store_test_results: &store_test_results
+          path: ~/cli/reports
+  cli_integration:
+    steps:
+      - run:
+          name: Snapshot command test
+          command: yarn test-snapshot-command
+      - run:
+          name: Upload command test
+          command: yarn test-upload-command
+  cli_commands:
+    steps:
+      - run:
           name: Version command
           command: ./bin/run --version
       - run:
           name: Help command
           command: ./bin/run --help
-      - run:
-          name: Build package
-          command: yarn build
+
+version: 2.1
+jobs:
+  node-10:
+    <<: *test_config
+    docker:
+      - image: circleci/node:10-browsers
+    steps:
+      - setup
+      - cli_commands
       - run:
           name: Unit tests
           command: |
@@ -37,33 +64,46 @@ jobs:
       - run:
           name: Client tests
           command: $NYC yarn test-client --singleRun
-      # [skipped] this uploads 0 snapshots and needs to be fixed
-      # - run:
-      #     name: Snapshot command test
-      #     command: yarn test-snapshot-command
-      - run:
-          name: Upload command test
-          command: yarn test-upload-command
       - run:
           name: Integration tests
           command: $NYC yarn test-integration
       - run:
-          name: Gather reports
-          command: $NYC report --reporter text-lcov > coverage.lcov
-      - store_test_results: &store_test_results
-          path: ~/cli/reports
+          name: Disable Percy for CLI integration tests
+          command: export PERCY_ENABLE=0
+      - cli_integration
+      - store_artifacts
   node-8:
-    <<: *test
+    <<: *test_config
     docker:
       - image: circleci/node:8-browsers
+    steps:
+      - setup
+      - cli_commands
+      - run:
+          name: Unit tests
+          command: |
+            mkdir -p reports
+            $NYC yarn test --reporter mocha-junit-reporter
+      - run:
+          name: Client tests
+          command: $NYC yarn test-client --singleRun
+      - run:
+          name: Integration tests
+          command: $NYC yarn test-integration
+      - cli_integration
+      - store_artifacts
   finalize_percy:
-    <<: *test
+    <<: *test_config
+    docker:
+      - image: circleci/node:8-browsers
     steps:
       - checkout
       - run: yarn && yarn build
       - run: ./bin/run finalize --all
   release:
-    <<: *test
+    <<: *test_config
+    docker:
+      - image: circleci/node:8-browsers
     steps:
       - checkout
       - run: yarn
@@ -71,7 +111,7 @@ jobs:
       - run: ./release-percy.sh
 workflows:
   version: 2
-  "@percy/agent":
+  default:
     jobs:
       - node-10
       - node-8

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "test": "yarn build-client && PERCY_TOKEN=abc mocha --forbid-only \"test/**/*.test.ts\" --exclude \"test/percy-agent-client/**/*.test.ts\" --exclude \"test/integration/**/*\"",
     "test-client": "karma start ./test/percy-agent-client/karma.conf.js",
     "test-integration": "yarn build-client && node ./bin/run exec -h *.localtest.me -c .ci.percy.yml -- mocha test/integration/**/*.test.ts",
-    "test-snapshot-command": "./bin/run snapshot test/integration/test-static-site -b /dummy-base-url -i '(red-keep)' -s '\\.(html)$'",
+    "test-snapshot-command": "./bin/run snapshot test/integration/test-static-site -b /dummy-base-url/ -i **/red-keep.** -s **/*.{html}",
     "test-upload-command": "./bin/run upload test/integration/test-static-images",
     "version": "oclif-dev readme && git add README.md",
     "watch": "npm-watch"

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -13,7 +13,7 @@ const expect = chai.expect
 declare var PercyAgent: any
 
 async function snapshot(page: puppeteer.Page, name: string, options: any = {}) {
-  const nodeName = `${process.version} - ${name}`
+  const nodeName = `node-${process.version.replace('v', '').split('.')[0]} - ${name}`
   await page.addScriptTag({path: agentJsFilename()})
 
   const domSnapshot = await page.evaluate((name: string, options: any) => {

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -23,7 +23,7 @@ async function snapshot(page: puppeteer.Page, name: string, options: any = {}) {
   }, nodeName, options)
 
   await postSnapshot({
-    nodeName,
+    name: nodeName,
     domSnapshot,
     url: page.url(),
     clientInfo: 'integration-microSDK',

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -13,16 +13,17 @@ const expect = chai.expect
 declare var PercyAgent: any
 
 async function snapshot(page: puppeteer.Page, name: string, options: any = {}) {
+  const nodeName = `${process.version} - ${name}`
   await page.addScriptTag({path: agentJsFilename()})
 
   const domSnapshot = await page.evaluate((name: string, options: any) => {
     const percyAgentClient = new PercyAgent({ handleAgentCommunication: false })
 
     return percyAgentClient.snapshot(name, options)
-  }, name, options)
+  }, nodeName, options)
 
   await postSnapshot({
-    name,
+    nodeName,
     domSnapshot,
     url: page.url(),
     clientInfo: 'integration-microSDK',


### PR DESCRIPTION
## What is this?

As we've added more features to agent our testing config has been creaking a bit. This doesn't fix our testing woes we're feeling, but it does make it so all of the snapshots kicked off from CI in this repo are combined into the same Percy build. This will prevent this 2 snapshot build from eventually trolling our baseline:

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/2072894/66608230-ac8df500-eb7b-11e9-81ff-2647fe667a2f.png">

We add the node version to the snapshot name to prevent duplicates.

## Learning

CircleCI commands are awesome! https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21 You can combine many steps together to reuse across jobs (which is exactly what I did)