### PR TITLE
build(deps): bump axios from 0.18.1 to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "@oclif/plugin-not-found": "^1.2",
-    "axios": "^0.18.1",
+    "axios": "^0.19.0",
     "body-parser": "^1.18.3",
     "colors": "^1.3.2",
     "cors": "^2.8.4",

--- a/src/commands/health-check.ts
+++ b/src/commands/health-check.ts
@@ -9,6 +9,7 @@ export default class HealthCheck extends Command {
   static flags = {
     port: flags.integer({
       char: 'p',
+      default: DEFAULT_CONFIGURATION.agent.port,
       description: [
         `[default: ${DEFAULT_CONFIGURATION.agent.port}]`,
         'Port',

--- a/src/utils/health-checker.ts
+++ b/src/utils/health-checker.ts
@@ -12,13 +12,11 @@ async function healthCheck(port: number, retryOptions?: object) {
     ...retryOptions,
   }
 
-  const interceptorId = retryAxios.attach()
+  const axiosInstance = Axios.create({ raxConfi: retryConfig } as any)
 
-  await Axios({
-    method: 'get',
-    url: healthcheckUrl,
-    raxConfig: retryConfig,
-  } as any).then(() => {
+  const interceptorId = retryAxios.attach(axiosInstance)
+
+  await axiosInstance.get(healthcheckUrl).then(() => {
     logger.info('percy is ready.')
   }).catch((error) => {
     logger.error(`Failed to establish a connection with ${healthcheckUrl}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,10 +1766,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
-  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
   dependencies:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"


### PR DESCRIPTION
Axios 0.19.0 introduced a change which ignored custom configs (axios/axios#1718) such as `retry-axios`'s `raxConfig`. A fix for this behaviour was recently merged (axios/axios#2207) but there wasn't any release since.

This PR uses a new axios instance instead, thus bypassing the problematic code.
It also fixes a missing default port configuration for the `HealthCheck` command.

Fixes #226 