### PR TITLE
feat: Allow passing in CHROMIUM_PATH environment variable

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -44,6 +44,7 @@ export class AssetDiscoveryService extends PercyClientService {
         '--no-sandbox',
         '--disable-web-security',
       ],
+      executablePath: process.env.CHROMIUM_PATH,
       ignoreHTTPSErrors: true,
       handleSIGINT : false,
     })

--- a/src/services/static-snapshot-service.ts
+++ b/src/services/static-snapshot-service.ts
@@ -38,6 +38,7 @@ export default class StaticSnapshotService {
 
     const browser = await puppeteer.launch({
       args: ['--no-sandbox'],
+      executablePath: process.env.CHROMIUM_PATH,
       handleSIGINT : false,
     })
 


### PR DESCRIPTION
I was trying to run Percy in our project’s current e2e test setup (running on Alpine, a minimal Docker image) but found I wasn’t able to change the Chromium path for the Puppeteer client in `percy-agent`, so I would like to suggest this solution to the problem.

See the issue described here: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
> Getting headless Chrome up and running in Docker can be tricky. The bundled Chromium that Puppeteer installs is missing the necessary shared library dependencies.
> To fix, you'll need to install the missing dependencies and the latest Chromium package in your Docker file

An alternative solution would be to add the chromium path as an option in the Percy config or as a CLI option, but I would prefer it being an environment variable so it can be shared with the project’s puppeteer setup