### PR TITLE
build: Update `percy-js` dep to v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "globby": "^10.0.1",
     "image-size": "^0.8.2",
     "js-yaml": "^3.13.1",
-    "percy-client": "^3.1.0",
+    "percy-client": "^3.2.0",
     "puppeteer": "^1.13.0",
     "retry-axios": "^1.0.1",
     "winston": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7759,10 +7759,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-percy-client@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-3.1.0.tgz#f072e3c3e9c978a1666f77bb950ab804b9d1efa1"
-  integrity sha512-OzKg+o0dtt/LxcCNHNpe7B+oZ196fMiPFzySvFz1ouXNoEBITiborIGN49e8dN5puwIEILoePlX91q6C834XGg==
+percy-client@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-3.2.1.tgz#42c265fcca6b9bf8eccfc53a793098286d363a95"
+  integrity sha512-xnoLe1QNT5Y/1PEZqKdES9aOtvd1TyyaVdKPbq1sWh1ORLFhgPte3Yg9+vnmUyjplDsHEev32tzmEAx2PMMbOw==
   dependencies:
     base64-js "^1.2.3"
     bluebird "^3.5.1"


### PR DESCRIPTION
## What is this?

This carries two parallel bug fixes, one which fixes rebuilds on CircleCI (which will help agents CI builds): https://github.com/percy/percy-js/releases/tag/v3.2.1