### PR TITLE
fix: start detached and stop cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
           name: Unit tests
           command: |
             mkdir -p reports
-            $NYC yarn test --reporter mocha-junit-reporter
+            $NYC yarn test
       - run:
           name: Client tests
           command: $NYC yarn test-client --singleRun

--- a/src/commands/percy-command.ts
+++ b/src/commands/percy-command.ts
@@ -53,13 +53,13 @@ export default class PercyCommand extends Command {
       this.logStart()
 
       // Receiving any of these events should stop the agent and exit
-      process.on('SIGHUP', () => this.stop())
-      process.on('SIGINT', () => this.stop())
-      process.on('SIGTERM', () => this.stop())
+      process.on('SIGHUP', () => this.stop(0, true))
+      process.on('SIGINT', () => this.stop(0, true))
+      process.on('SIGTERM', () => this.stop(0, true))
     }
   }
 
-  async stop(exitCode?: number | null) {
+  async stop(exitCode?: number | null, stopProcess?: boolean) {
     if (this.exiting) { return }
     this.exiting = true
 
@@ -67,6 +67,10 @@ export default class PercyCommand extends Command {
       await this.agentService.stop()
     }
 
-    process.exit(exitCode || 0)
+    if (stopProcess) {
+      process.exit(exitCode || 0)
+    } else {
+      this.exit(exitCode || 0)
+    }
   }
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -67,11 +67,20 @@ export default class Start extends PercyCommand {
   }
 
   private runDetached(flags: any) {
+    let args: string[] = []
+
+    if (flags.port) {
+      args = args.concat('-p', flags.port)
+    }
+
+    if (flags['network-idle-timeout']) {
+      args = args.concat('-t', flags['network-idle-timeout'])
+    }
+
     const pid = this.processService.runDetached([
       path.resolve(`${__dirname}/../../bin/run`),
       'start',
-      '-p', String(flags.port!),
-      '-t', String(flags['network-idle-timeout']),
+      ...args,
     ])
 
     if (pid) {

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -113,7 +113,7 @@ export class AgentService {
 
     if (domSnapshot.length > Constants.MAX_FILE_SIZE_BYTES) {
       logger.info(`snapshot skipped[max_file_size_exceeded]: '${request.body.name}'`)
-      return response.json({success: true})
+      return response.json({ success: true })
     }
 
     let resources = await this.snapshotService.buildResources(
@@ -157,7 +157,7 @@ export class AgentService {
 
   private async handleStop(_: express.Request, response: express.Response) {
     await this.stop()
-    new ProcessService().kill()
+    new ProcessService().cleanup()
     return response.json({ success: true })
   }
 

--- a/src/utils/health-checker.ts
+++ b/src/utils/health-checker.ts
@@ -1,9 +1,10 @@
 import Axios from 'axios'
 import * as retryAxios from 'retry-axios'
+import { DEFAULT_PORT, HEALTHCHECK_PATH } from '../services/agent-service-constants'
 import logger from './logger'
 
-async function healthCheck(port: number, retryOptions?: object) {
-  const healthcheckUrl = `http://localhost:${port}/percy/healthcheck`
+async function healthCheck(port: number = DEFAULT_PORT, retryOptions?: object) {
+  const healthcheckUrl = `http://localhost:${port}${HEALTHCHECK_PATH}`
 
   const retryConfig = {
     retry: 5, // with exponential back off

--- a/test/commands/start.test.ts
+++ b/test/commands/start.test.ts
@@ -90,17 +90,15 @@ describe('Start', () => {
     it('starts percy agent on a specific port', async () => {
       const agentServiceStub = AgentServiceStub()
 
-      const port = '55000'
-      const options = ['--port', port]
-
       const stdout = await captureStdOut(async () => {
-        await Start.run(options)
+        await Start.run(['--port', '55000'])
       })
 
-      const expectedConfiguration = DEFAULT_CONFIGURATION
-      expectedConfiguration.agent.port = +port
+      expect(agentServiceStub.start).to.calledWithMatch({
+        ...DEFAULT_CONFIGURATION,
+        agent: { ...DEFAULT_CONFIGURATION.agent, port: 55000 },
+      })
 
-      expect(agentServiceStub.start).to.calledWithMatch(expectedConfiguration)
       expect(stdout).to.contain('[percy] percy has started.')
     })
 

--- a/test/commands/start.test.ts
+++ b/test/commands/start.test.ts
@@ -1,4 +1,3 @@
-import * as chai from 'chai'
 import {describe} from 'mocha'
 import * as nock from 'nock'
 import * as path from 'path'
@@ -8,6 +7,7 @@ import { DEFAULT_CONFIGURATION } from '../../src/configuration/configuration'
 import {AgentService} from '../../src/services/agent-service'
 import ProcessService from '../../src/services/process-service'
 import {captureStdOut} from '../helpers/stdout'
+import chai from '../support/chai'
 
 const expect = chai.expect
 
@@ -66,8 +66,23 @@ describe('Start', () => {
         [
           path.resolve(`${__dirname}/../../bin/run`),
           'start',
-          '-p', String(DEFAULT_CONFIGURATION.agent.port),
-          '-t', '50',
+        ],
+      )
+    })
+
+    it('starts percy agent in detached mode with flags', async () => {
+      const processService = ProcessServiceStub()
+
+      await captureStdOut(async () => {
+        await Start.run(['--detached', '-p', '55000', '-t', '100'])
+      })
+
+      expect(processService.runDetached).to.calledWithMatch(
+        [
+          path.resolve(`${__dirname}/../../bin/run`),
+          'start',
+          '-p', 55000,
+          '-t', 100,
         ],
       )
     })

--- a/test/helpers/stdout.ts
+++ b/test/helpers/stdout.ts
@@ -2,16 +2,28 @@ import * as std from 'stdout-stderr'
 
 export async function captureStdOut(callback: any): Promise<string> {
   std.stdout.start()
-  await callback()
-  std.stdout.stop()
+
+  try {
+    await callback()
+  } catch (err) {
+    if (!err.oclif || err.oclif.exit !== 0) { throw err }
+  } finally {
+    std.stdout.stop()
+  }
 
   return std.stdout.output
 }
 
 export async function captureStdErr(callback: any): Promise<string> {
   std.stderr.start()
-  await callback()
-  std.stderr.stop()
+
+  try {
+    await callback()
+  } catch (err) {
+    if (!err.oclif || err.oclif.exit !== 0) { throw err }
+  } finally {
+    std.stderr.stop()
+  }
 
   return std.stderr.output
 }


### PR DESCRIPTION
## Purpose

An issue was brought up where the start and stop commands did not work as expected with the latest version of agent. In fixing that issue, I discovered that our test suite was not finishing and was exiting with a `0` status early.

After digging through CircleCI builds, I am unable to determine when these tests started to not be run in CI. It seem the very fist passing build has a warning about Percy exiting. Previous test runs cannot be viewed due to the junit mocha reporter only saving reports to a file.

## Approach

- Defaulted healthcheck helper argument to the default port and also made use of the healthcheck endpoint constant.

- Since flags no longer have defaults, we were passing the string `"undefined"` into the detached start process. This was fixed by conditionally setting those flags.

- The stop endpoint finalized the build, closed the server, and killed the running process. That last part caused builds to be re-finalized, therefore creating empty duplicate builds. This was fixed by cleaning up the PID file rather than outright killing the process. Since the server closes, the process will close anyway.

- Use the oclif `this.exit` method. Using `process.exit` caused the _mocha process_ to exit. Oclif exit stops script execution by throwing an error, so callbacks that referenced the stop method had to be adjusted.
  - Shared process handlers now pass a boolean to exit the process
  - The other call to stop in `exec` needed to be moved out of the callbacks and called after the subprocess exited. This subprocess was turned into a promise so that errors can be caught and we can always call close without creating an unhandled rejection.
  - The stdio test helpers were updated to ignore safe oclif exits

- All failing tests were fixed and updated. Even the skipped exec tests can be re-enabled. A couple of tests were removed due to them never working or being superseded by another change.

- Finally, junit was removed as the sole reporter so we can actually see the results of our tests in CI.
