### PR TITLE
fix: Pass along second arg to PercyCommand's `stop`

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -61,9 +61,9 @@ export default class Start extends PercyCommand {
     await healthCheck(flags.port!)
   }
 
-  async stop(exitCode?: any) {
+  async stop(exitCode?: any, stopProcess?: boolean) {
     this.processService.cleanup()
-    await super.stop(exitCode)
+    await super.stop(exitCode, stopProcess)
   }
 
   private runDetached(flags: any) {


### PR DESCRIPTION
## What is this?

We weren't properly passing along a second arg to `stop`, which would cause `UnhandledPromiseRejectionWarning`'s (#408)