### PR TITLE
fix: ensure CSSOM ownerNode content is present

### DIFF
--- a/src/percy-agent-client/dom.ts
+++ b/src/percy-agent-client/dom.ts
@@ -173,7 +173,7 @@ class DOM {
         const hasHref = styleSheet.href
         const ownerNode = styleSheet.ownerNode as HTMLElement
         const ownerNodeInnerContent = ownerNode.innerText && ownerNode.innerText.trim()
-        const hasStyleInDom = ownerNodeInnerContent.length > 0
+        const hasStyleInDom = !!ownerNodeInnerContent && ownerNodeInnerContent.length > 0
 
         return !hasHref && !hasStyleInDom && styleSheet.cssRules
       }


### PR DESCRIPTION
## What is this?

Turns out, innerText can return undefined (for reasons?), so we should ensure there is something present before trying to check the length of it. See this for a reproduction: https://jsfiddle.net/nbpqaz97/1/

Will close #416 #417 (and maybe #415)