### PR TITLE
feat: Introduce asset discovery response caching behind flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "test": "yarn test:unit && yarn test:client && yarn test:integration && yarn test:command:snapshot && yarn test:command:upload",
     "test:unit": "PERCY_TOKEN=abc mocha \"test/**/*.test.ts\" --exclude \"test/percy-agent-client/**/*.test.ts\" --exclude \"test/integration/**/*\"",
     "test:client": "karma start ./test/percy-agent-client/karma.conf.js",
-    "test:integration": "yarn build-client && node ./bin/run exec -r -h *.localtest.me -c .ci.percy.yml -- mocha test/integration/**/*.test.ts",
+    "test:integration": "yarn build-client && node ./bin/run exec -h *.localtest.me -c .ci.percy.yml -- mocha test/integration/**/*.test.ts",
     "test:command:snapshot": "./bin/run snapshot test/integration/test-static-site -b /dummy-base-url/ -i **/red-keep.** -s **/*.{html}",
     "test:command:upload": "./bin/run upload test/integration/test-static-images",
     "version": "oclif-dev readme && git add README.md",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "test": "yarn test:unit && yarn test:client && yarn test:integration && yarn test:command:snapshot && yarn test:command:upload",
     "test:unit": "PERCY_TOKEN=abc mocha \"test/**/*.test.ts\" --exclude \"test/percy-agent-client/**/*.test.ts\" --exclude \"test/integration/**/*\"",
     "test:client": "karma start ./test/percy-agent-client/karma.conf.js",
-    "test:integration": "yarn build-client && node ./bin/run exec -h *.localtest.me -c .ci.percy.yml -- mocha test/integration/**/*.test.ts",
+    "test:integration": "yarn build-client && node ./bin/run exec -r -h *.localtest.me -c .ci.percy.yml -- mocha test/integration/**/*.test.ts",
     "test:command:snapshot": "./bin/run snapshot test/integration/test-static-site -b /dummy-base-url/ -i **/red-keep.** -s **/*.{html}",
     "test:command:upload": "./bin/run upload test/integration/test-static-images",
     "version": "oclif-dev readme && git add README.md",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "test": "yarn test:unit && yarn test:client && yarn test:integration && yarn test:command:snapshot && yarn test:command:upload",
     "test:unit": "PERCY_TOKEN=abc mocha \"test/**/*.test.ts\" --exclude \"test/percy-agent-client/**/*.test.ts\" --exclude \"test/integration/**/*\"",
     "test:client": "karma start ./test/percy-agent-client/karma.conf.js",
-    "test:integration": "yarn build-client && node ./bin/run exec -h *.localtest.me -c .ci.percy.yml -- mocha test/integration/**/*.test.ts",
+    "test:integration": "yarn build-client && node ./bin/run exec --cache-responses -h *.localtest.me -c .ci.percy.yml -- mocha test/integration/**/*.test.ts",
     "test:command:snapshot": "./bin/run snapshot test/integration/test-static-site -b /dummy-base-url/ -i **/red-keep.** -s **/*.{html}",
     "test:command:upload": "./bin/run upload test/integration/test-static-images",
     "version": "oclif-dev readme && git add README.md",

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -27,6 +27,13 @@ export default class Exec extends PercyCommand {
         'Asset discovery network idle timeout (in milliseconds)',
       ].join(' '),
     }),
+    'cache-responses': flags.boolean({
+      char: 'r', // ?????????
+      description: [
+        `[default: ${DEFAULT_CONFIGURATION.agent['asset-discovery']['cache-responses']}]`,
+        'Enable caching network responses for asset discovery',
+      ].join(' '),
+    }),
     'port': flags.integer({
       char: 'p',
       description: [

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -28,10 +28,9 @@ export default class Exec extends PercyCommand {
       ].join(' '),
     }),
     'cache-responses': flags.boolean({
-      char: 'r', // ?????????
       description: [
         `[default: ${DEFAULT_CONFIGURATION.agent['asset-discovery']['cache-responses']}]`,
-        'Enable caching network responses for asset discovery',
+        'Enable caching network responses for asset discovery (experimental)',
       ].join(' '),
     }),
     'port': flags.integer({

--- a/src/configuration/asset-discovery-configuration.ts
+++ b/src/configuration/asset-discovery-configuration.ts
@@ -4,4 +4,5 @@ export interface AssetDiscoveryConfiguration {
   'network-idle-timeout': number,
   'page-pool-size-min': number,
   'page-pool-size-max': number
+  'cache-responses': boolean
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -27,6 +27,7 @@ export const DEFAULT_CONFIGURATION: Configuration = {
       'network-idle-timeout': 50, // ms
       'page-pool-size-min': 1, // pages
       'page-pool-size-max': 5, // pages
+      'cache-responses': false,
     },
   },
   'static-snapshots': {

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -207,9 +207,9 @@ export class AssetDiscoveryService extends PercyClientService {
           return
         }
 
-        if (this.configuration['cache-responses'] === true && getResponseCache()[requestUrl]) {
+        if (this.configuration['cache-responses'] === true && getResponseCache(requestUrl)) {
           logger.debug(`Asset cache hit for ${requestUrl}`)
-          await request.respond(getResponseCache()[requestUrl])
+          await request.respond(getResponseCache(requestUrl))
 
           return
         }

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -14,9 +14,15 @@ const requestCache = {} as any
 
 async function cacheResponse(response: puppeteer.Response, logger: any) {
   const responseUrl = response.url()
+  const statusCode = response.status()
 
   if (!!requestCache[responseUrl]) {
     console.log('already in cache', responseUrl)
+    return
+  }
+
+  if (![200, 201].includes(statusCode)) {
+    console.log('Not a 200 response, skipping')
     return
   }
 

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -12,21 +12,25 @@ import ResponseService from './response-service'
 export const MAX_SNAPSHOT_WIDTHS: number = 10
 const requestCache = {} as any
 
+/**
+ * Keep an in-memory cache of asset responses.
+ *
+ * When enabled, asset responses will be kept in memory. When the asset is
+ * re-requested, it will be responsed with what the cached response. This makes
+ * it so servers aren't being hounded for the same asset over and over again.
+ */
 async function cacheResponse(response: puppeteer.Response, logger: any) {
   const responseUrl = response.url()
   const statusCode = response.status()
 
   if (!!requestCache[responseUrl]) {
-    console.log('already in cache', responseUrl)
+    logger.debug(`Asset already in cache ${responseUrl}`)
     return
   }
 
   if (![200, 201].includes(statusCode)) {
-    console.log('Not a 200 response, skipping')
     return
   }
-
-  console.log('caching...', responseUrl)
 
   try {
     const buffer = await response.buffer()
@@ -238,8 +242,8 @@ export class AssetDiscoveryService extends PercyClientService {
           return
         }
 
-        if (requestCache[requestUrl] && this.configuration['cache-responses'] === true) {
-          console.log('cache hit!', requestUrl)
+        if (this.configuration['cache-responses'] === true && requestCache[requestUrl]) {
+          logger.debug(`Asset cache hit for ${requestUrl}`)
           await request.respond(requestCache[requestUrl])
 
           return

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -41,6 +41,7 @@ function transform(flags: any, args: any) {
       'asset-discovery': {
         'allowed-hostnames': flags['allowed-hostname'],
         'network-idle-timeout': flags['network-idle-timeout'],
+        'cache-responses': flags['cache-responses'],
       },
     },
     'static-snapshots': {

--- a/src/utils/response-cache.ts
+++ b/src/utils/response-cache.ts
@@ -36,8 +36,8 @@ export async function cacheResponse(response: Response, logger: any) {
   }
 }
 
-export function getResponseCache() {
-  return responseCache
+export function getResponseCache(url: string) {
+  return responseCache[url]
 }
 
 export function _setResponseCache(newResponseCache: any) {

--- a/src/utils/response-cache.ts
+++ b/src/utils/response-cache.ts
@@ -1,0 +1,41 @@
+import { Response } from 'puppeteer'
+const responseCache = {} as any
+
+/**
+ * Keep an in-memory cache of asset responses.
+ *
+ * When enabled, asset responses will be kept in memory. When the asset is
+ * re-requested, it will be responsed with what the cached response. This makes
+ * it so servers aren't being hounded for the same asset over and over again.
+ */
+export async function cacheResponse(response: Response, logger: any) {
+  const responseUrl = response.url()
+  const statusCode = response.status()
+
+  if (!!responseCache[responseUrl]) {
+    logger.debug(`Asset already in cache ${responseUrl}`)
+    return
+  }
+
+  if (![200, 201].includes(statusCode)) {
+    return
+  }
+
+  try {
+    const buffer = await response.buffer()
+
+    responseCache[responseUrl] = {
+      status: response.status(),
+      headers: response.headers(),
+      body: buffer,
+    }
+
+    logger.debug(`Added ${responseUrl} to asset discovery cache`)
+  } catch (error) {
+    logger.debug(`Could not cache response ${responseUrl}: ${error}`)
+  }
+}
+
+export function getResponseCache() {
+  return responseCache
+}

--- a/src/utils/response-cache.ts
+++ b/src/utils/response-cache.ts
@@ -1,5 +1,5 @@
 import { Response } from 'puppeteer'
-const responseCache = {} as any
+let responseCache = {} as any
 
 /**
  * Keep an in-memory cache of asset responses.
@@ -37,5 +37,11 @@ export async function cacheResponse(response: Response, logger: any) {
 }
 
 export function getResponseCache() {
+  return responseCache
+}
+
+export function _setResponseCache(newResponseCache: any) {
+  responseCache = newResponseCache
+
   return responseCache
 }

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -88,8 +88,6 @@ describe('Integration test', () => {
       await page.goto('https://buildkite.com/')
       const domSnapshot = await snapshot(page, 'Buildkite snapshot')
       expect(domSnapshot).contains('Buildkite')
-      await snapshot(page, 'Buildkite snapshot #2')
-      await snapshot(page, 'Buildkite snapshot #3')
     })
 
     it('snapshots a site with redirected assets', async () => {

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -88,6 +88,8 @@ describe('Integration test', () => {
       await page.goto('https://buildkite.com/')
       const domSnapshot = await snapshot(page, 'Buildkite snapshot')
       expect(domSnapshot).contains('Buildkite')
+      await snapshot(page, 'Buildkite snapshot #2')
+      await snapshot(page, 'Buildkite snapshot #3')
     })
 
     it('snapshots a site with redirected assets', async () => {

--- a/test/utils/response-cache.test.ts
+++ b/test/utils/response-cache.test.ts
@@ -37,7 +37,7 @@ describe('Response cache util', () => {
 
   it('calling the cache with the same URL does nothing', async () => {
     await cacheResponse(defaultResponse, logger)
-    await cacheResponse(defaultResponse, logger)
+    await cacheResponse({ ...defaultResponse, status() { return 201 } }, logger)
 
     expect(getResponseCache('http://example.com/foo.txt')).to.eql({
       status: 200,

--- a/test/utils/response-cache.test.ts
+++ b/test/utils/response-cache.test.ts
@@ -19,11 +19,7 @@ describe('Response cache util', () => {
   it('200 status code response adds to the cache', async () => {
     await cacheResponse(defaultResponse, logger)
 
-    const responseCache = getResponseCache()
-    const cacheArray = Object.keys(responseCache)
-
-    expect(cacheArray.length).to.eql(1)
-    expect(responseCache['http://example.com/foo.txt']).to.eql({
+    expect(getResponseCache('http://example.com/foo.txt')).to.eql({
       status: 200,
       body: 'hello',
       headers: 'fake headers',
@@ -33,11 +29,7 @@ describe('Response cache util', () => {
   it('201 status code response adds to the cache', async () => {
     await cacheResponse({ ...defaultResponse, status() { return  201 } }, logger)
 
-    const responseCache = getResponseCache()
-    const cacheArray = Object.keys(responseCache)
-
-    expect(cacheArray.length).to.eql(1)
-    expect(responseCache['http://example.com/foo.txt']).to.eql({
+    expect(getResponseCache('http://example.com/foo.txt')).to.eql({
       status: 201,
       body: 'hello',
       headers: 'fake headers',
@@ -48,11 +40,7 @@ describe('Response cache util', () => {
     await cacheResponse(defaultResponse, logger)
     await cacheResponse(defaultResponse, logger)
 
-    const responseCache = getResponseCache()
-    const cacheArray = Object.keys(responseCache)
-
-    expect(cacheArray.length).to.eql(1)
-    expect(responseCache['http://example.com/foo.txt']).to.eql({
+    expect(getResponseCache('http://example.com/foo.txt')).to.eql({
       status: 200,
       body: 'hello',
       headers: 'fake headers',
@@ -65,9 +53,6 @@ describe('Response cache util', () => {
     await cacheResponse({ ...defaultResponse, status() { return 401 } }, logger)
     await cacheResponse({ ...defaultResponse, status() { return 404 } }, logger)
 
-    const responseCache = getResponseCache()
-    const cacheArray = Object.keys(responseCache)
-
-    expect(cacheArray.length).to.eql(0)
+    expect(getResponseCache('http://example.com/foo.txt')).to.eql(undefined)
   })
 })

--- a/test/utils/response-cache.test.ts
+++ b/test/utils/response-cache.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai'
+import { _setResponseCache, cacheResponse, getResponseCache } from '../../src/utils/response-cache'
+
+// Mock logger
+const logger = { debug() { return '' }}
+const defaultResponse = {
+  url() { return 'http://example.com/foo.txt' },
+  status() { return 200 },
+  headers() { return 'fake headers' },
+  buffer() { return 'hello' },
+  body: 'hello',
+} as any
+
+describe('Response cache util', () => {
+  beforeEach(() => {
+    _setResponseCache({})
+  })
+
+  it('200 status code response adds to the cache', async () => {
+    await cacheResponse(defaultResponse, logger)
+
+    const responseCache = getResponseCache()
+    const cacheArray = Object.keys(responseCache)
+
+    expect(cacheArray.length).to.eql(1)
+    expect(responseCache['http://example.com/foo.txt']).to.eql({
+      status: 200,
+      body: 'hello',
+      headers: 'fake headers',
+    })
+  })
+
+  it('201 status code response adds to the cache', async () => {
+    await cacheResponse({ ...defaultResponse, status() { return  201 } }, logger)
+
+    const responseCache = getResponseCache()
+    const cacheArray = Object.keys(responseCache)
+
+    expect(cacheArray.length).to.eql(1)
+    expect(responseCache['http://example.com/foo.txt']).to.eql({
+      status: 201,
+      body: 'hello',
+      headers: 'fake headers',
+    })
+  })
+
+  it('calling the cache with the same URL does nothing', async () => {
+    await cacheResponse(defaultResponse, logger)
+    await cacheResponse(defaultResponse, logger)
+
+    const responseCache = getResponseCache()
+    const cacheArray = Object.keys(responseCache)
+
+    expect(cacheArray.length).to.eql(1)
+    expect(responseCache['http://example.com/foo.txt']).to.eql({
+      status: 200,
+      body: 'hello',
+      headers: 'fake headers',
+    })
+  })
+
+  it('non-200 status code response does not add to the cache', async () => {
+    await cacheResponse({ ...defaultResponse, status() { return 300 } }, logger)
+    await cacheResponse({ ...defaultResponse, status() { return 500 } }, logger)
+    await cacheResponse({ ...defaultResponse, status() { return 401 } }, logger)
+    await cacheResponse({ ...defaultResponse, status() { return 404 } }, logger)
+
+    const responseCache = getResponseCache()
+    const cacheArray = Object.keys(responseCache)
+
+    expect(cacheArray.length).to.eql(0)
+  })
+})

--- a/test/utils/response-cache.test.ts
+++ b/test/utils/response-cache.test.ts
@@ -8,7 +8,6 @@ const defaultResponse = {
   status() { return 200 },
   headers() { return 'fake headers' },
   buffer() { return 'hello' },
-  body: 'hello',
 } as any
 
 describe('Response cache util', () => {


### PR DESCRIPTION
## What is this?

Sometimes the Percy Agent asset discovery service can overload a customers test server, which means sometimes snapshots are missing assets. Right now, we hit their applications test server for each asset at each width. 

Off by default, this PR introduces a way to enable response caching for asset discovery. This is so our asset discovery service only will hit their applications test server for a given asset once (if we get a 200 response). In theory, it should reduce the number of SDK related missing assets (most commonly seen in rails apps)