### PR TITLE
fix: Add better logging for command not found errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "@oclif/plugin-not-found": "^1.2",
+    "@types/which": "^1.3.2",
     "axios": "^0.19.0",
     "body-parser": "^1.18.3",
     "colors": "^1.3.2",
@@ -38,6 +39,7 @@
     "percy-client": "^3.2.0",
     "puppeteer": "^1.13.0",
     "retry-axios": "^1.0.1",
+    "which": "^2.0.1",
     "winston": "^3.0.0"
   },
   "devDependencies": {

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -1,5 +1,6 @@
 import { flags } from '@oclif/command'
 import * as spawn from 'cross-spawn'
+import * as which from 'which'
 import { DEFAULT_CONFIGURATION } from '../configuration/configuration'
 import config from '../utils/configuration'
 import PercyCommand from './percy-command'
@@ -56,7 +57,12 @@ export default class Exec extends PercyCommand {
       this.logger.info('You must supply a command to run after --')
       this.logger.info('Example:')
       this.logger.info('$ percy exec -- echo "run your test suite"')
-      return
+      return this.exit(1)
+    }
+
+    if (which.sync(command, { nothrow: true }) == null) {
+      this.logger.error(`Error: command not found "${command}"`)
+      return this.exit(127)
     }
 
     if (this.percyWillRun()) {
@@ -70,7 +76,7 @@ export default class Exec extends PercyCommand {
       spawnedProcess.on('error', reject)
     }).catch((error) => {
       // catch subprocess errors
-      this.logger.error(error)
+      this.logger.error(error.toString())
       return 1
     }).then((code: any) => {
       // oclif exit raises an error to stop script execution, so the following

--- a/test/acceptance/exec.test.js
+++ b/test/acceptance/exec.test.js
@@ -18,6 +18,26 @@ describe('percy exec', () => {
     expect(stdout).toHaveEntry('test')
   })
 
+  it('logs a message when missing a command', async () => {
+    let [stdout, stderr, code] = await run('percy exec')
+
+    expect(code).toEqual(1)
+    expect(stderr).toHaveLength(0)
+    expect(stdout).toHaveEntries([
+      '[percy] You must supply a command to run after --',
+      '[percy] Example:',
+      '[percy] $ percy exec -- echo "run your test suite"'
+    ])
+  })
+
+  it('errors when the command cannot be found', async () => {
+    let [stdout, stderr, code] = await run('percy exec -- foobar')
+
+    expect(code).toEqual(127)
+    expect(stderr).toHaveEntry('[percy] Error: command not found "foobar"')
+    expect(stdout).toHaveLength(0)
+  })
+
   it('creates and finalizes a new build', async () => {
     let [stdout, stderr] = await run('percy exec -- echo test')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,6 +1327,11 @@
     "@types/cookiejar" "*"
     "@types/node" "*"
 
+"@types/which@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.2.tgz#9c246fc0c93ded311c8512df2891fb41f6227fdf"
+  integrity sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==
+
 "@types/yargs-parser@*":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"


### PR DESCRIPTION
## Purpose

We started noticing `[percy] undefined` in the logs whenever the command being executed was not found in the $PATH. This was due to the error object being passed through from the child's `error` handler being interpreted incorrectly by Winston 3.x. Winston attempts to find a `msg` property on the passed object, which is where `undefined` was coming from. Winston does have logic for handling Error instances, but for some reason the error provided by cross-spawn did not get handled like a normal Error.

Fixes #297 

## Approach

Call `.toString()` on the error to log the error message rather than the error object.

The error this produced was `spawn foobar ENOENT` which might not be obvious to some that it means the command was not found. So I utilized a transitive dependency `which` to perform a cross-platform check for the provided command so we can log a much friendlier error.

In addition, I added a non-zero exit code to the missing command logic and tested that as well.