### PR TITLE
fix: Wait for asset discovery finish when awaiting on snapshot resources in finalize

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -75,10 +75,6 @@ export class AgentService {
 
   private async handleSnapshot(request: express.Request, response: express.Response) {
     profile('agentService.handleSnapshot')
-    let resolve
-    let reject
-    const deferred = new Promise((...args) => [resolve, reject] = args)
-    this.snapshotCreationPromises.push(deferred)
 
     // truncate domSnapshot for the logs if it's very large
     const rootURL = request.body.url
@@ -119,6 +115,10 @@ export class AgentService {
       logger.info(`snapshot skipped[max_file_size_exceeded]: '${request.body.name}'`)
       return response.json({ success: true })
     }
+    // tslint:disable-next-line
+    let resolve, reject
+    const deferred = new Promise((...args) => [resolve, reject] = args)
+    this.snapshotCreationPromises.push(deferred)
 
     let resources = await this.snapshotService.buildResources(
       rootURL,

--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -75,6 +75,10 @@ export class AgentService {
 
   private async handleSnapshot(request: express.Request, response: express.Response) {
     profile('agentService.handleSnapshot')
+    let resolve
+    let reject
+    const deferred = new Promise((...args) => [resolve, reject] = args)
+    this.snapshotCreationPromises.push(deferred)
 
     // truncate domSnapshot for the logs if it's very large
     const rootURL = request.body.url
@@ -140,15 +144,14 @@ export class AgentService {
       this.snapshotService.buildLogResource(snapshotLog),
     )
 
-    const snapshotCreation = this.snapshotService.create(
+    this.snapshotService.create(
       request.body.name,
       resources,
       snapshotOptions,
       request.body.clientInfo,
       request.body.environmentInfo,
-    )
+    ).then(resolve).catch(reject)
 
-    this.snapshotCreationPromises.push(snapshotCreation)
     logger.info(`snapshot taken: '${request.body.name}'`)
 
     profile('agentService.handleSnapshot')

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -47,7 +47,7 @@ export default class ResourceService extends PercyClientService {
         snapshotResponse.response,
         snapshotResponse.resources,
       )
-      profile('-> resourceService.uploadMissingResources', {resources: resources.length})
+      profile(`-> resourceService.uploadMissingResources ${resources.length}`)
 
       return true
     } catch (error) {

--- a/src/services/snapshot-service.ts
+++ b/src/services/snapshot-service.ts
@@ -110,7 +110,7 @@ export default class SnapshotService extends PercyClientService {
 
       profile('-> snapshotService.finalizeSnapshot')
       await this.finalize(response.body.data.id)
-      profile('-> snapshotService.finalizeSnapshot', {snapshotId})
+      profile(`-> snapshotService.finalizeSnapshot ${snapshotId}`)
       return response
     }).catch(logError)
 

--- a/test/acceptance/asset-discovery.test.js
+++ b/test/acceptance/asset-discovery.test.js
@@ -12,7 +12,7 @@ describe('Asset discovery', () => {
   it('does not create snapshots while stopping a build', async () => {
     let [stdout] = await run('percy exec -- node ./test/acceptance/dummy/snapshot-error.js');
 
-    // TODO: Assert the "waitig for x" output & for no snapshot logs to occur *after*
+    // TODO: Assert the "waiting for x" output & for no snapshot logs to occur *after*
     expect(stdout).toHaveEntries([
       '[percy] percy has started.',
       "[percy] snapshot taken: 'Home Page - 0'",

--- a/test/acceptance/asset-discovery.test.js
+++ b/test/acceptance/asset-discovery.test.js
@@ -16,6 +16,7 @@ describe('Asset discovery', () => {
   it('does not create snapshots while stopping a build', async () => {
     let [stdout] = await run('percy exec -- node ./test/acceptance/dummy/snapshot-error.js');
 
+    // TODO: Assert the "waitig for x" output & for no snapshot logs to occur *after*
     expect(stdout).toHaveEntries([
       '[percy] percy has started.',
       "[percy] snapshot taken: 'Home Page - 0'",

--- a/test/acceptance/asset-discovery.test.js
+++ b/test/acceptance/asset-discovery.test.js
@@ -1,0 +1,26 @@
+import expect from 'expect'
+import { execSync } from 'child_process'
+import { when } from 'interactor.js'
+
+import {
+  launch,
+  run,
+  setupApiProxy,
+  setupDummyApp
+} from './helpers'
+
+describe('Asset discovery', () => {
+  let proxy = setupApiProxy()
+  let dummy = setupDummyApp()
+
+  it('does not create snapshots while stopping a build', async () => {
+    let [stdout] = await run('percy exec -- node ./test/acceptance/dummy/snapshot-error.js');
+
+    expect(stdout).toHaveEntries([
+      '[percy] percy has started.',
+      "[percy] snapshot taken: 'Home Page - 0'",
+      '[percy] done.',
+      '[percy] finalized build #4: <<build-url>>'
+    ])
+  })
+})

--- a/test/acceptance/asset-discovery.test.js
+++ b/test/acceptance/asset-discovery.test.js
@@ -9,13 +9,13 @@ describe('Asset discovery', () => {
   let proxy = setupApiProxy()
   let dummy = setupDummyApp()
 
-  it('does not create snapshots while stopping a build', async () => {
+  it('waits for snapshot creation before build finalization', async () => {
     let [stdout] = await run('percy exec -- node ./test/acceptance/dummy/snapshot-error.js');
+    let finalizeReqDate = proxy.requests['/builds/123/finalize'][0].timestamp;
+    let snapshotReqs = proxy.requests['/builds/123/snapshots'];
+    let lastSnapshotReqDate = snapshotReqs[snapshotReqs.length - 1].timestamp;
 
-    let finalizeReqDate = proxy.requests['/builds/123/finalize'][0].requestDate;
-    let lastSnapshotReqDate = proxy.requests['/builds/123/snapshots'].pop().requestDate;
-
-    expect(finalizeReqDate > lastSnapshotReqDate).toBe(true)
+    expect(finalizeReqDate).toBeGreaterThan(lastSnapshotReqDate)
     expect(stdout).toHaveEntries([
       '[percy] percy has started.',
       /^\[percy\] waiting for \d+ snapshots to complete\.\.\.$/m,

--- a/test/acceptance/asset-discovery.test.js
+++ b/test/acceptance/asset-discovery.test.js
@@ -12,9 +12,13 @@ describe('Asset discovery', () => {
   it('does not create snapshots while stopping a build', async () => {
     let [stdout] = await run('percy exec -- node ./test/acceptance/dummy/snapshot-error.js');
 
-    // TODO: Assert the "waiting for x" output & for no snapshot logs to occur *after*
+    let finalizeReqDate = proxy.requests['/builds/123/finalize'][0].requestDate;
+    let lastSnapshotReqDate = proxy.requests['/builds/123/snapshots'].pop().requestDate;
+
+    expect(finalizeReqDate > lastSnapshotReqDate).toBe(true)
     expect(stdout).toHaveEntries([
       '[percy] percy has started.',
+      /^\[percy\] waiting for \d+ snapshots to complete\.\.\.$/m,
       "[percy] snapshot taken: 'Home Page - 0'",
       '[percy] done.',
       '[percy] finalized build #4: <<build-url>>'

--- a/test/acceptance/asset-discovery.test.js
+++ b/test/acceptance/asset-discovery.test.js
@@ -1,9 +1,5 @@
 import expect from 'expect'
-import { execSync } from 'child_process'
-import { when } from 'interactor.js'
-
 import {
-  launch,
   run,
   setupApiProxy,
   setupDummyApp

--- a/test/acceptance/dummy/snapshot-error.js
+++ b/test/acceptance/dummy/snapshot-error.js
@@ -1,0 +1,17 @@
+// register babel for the snapshot helper
+require('@babel/register')
+require('regenerator-runtime/runtime')
+
+const launch = require('../helpers/snapshot').default
+
+launch(async (page, snapshot) => {
+  await page.goto('http://localhost:9999')
+
+  setTimeout(() => {
+    throw new Error('Surprise!')
+  }, 100) // magic number
+
+  for (let index = 0; index < 10; index++) {
+    await snapshot(`Home Page - ${index}`)
+  }
+})

--- a/test/acceptance/helpers/proxy.js
+++ b/test/acceptance/helpers/proxy.js
@@ -50,7 +50,7 @@ export function createApiProxy() {
   app.all('*', (req, res, next) => {
     let path = req.path.replace(/\/$/, '')
     requests[path] = requests[path] || []
-    requests[path].push({ requestDate: new Date(), ...req })
+    requests[path].push({ timestamp: Date.now(), ...req })
     next()
   })
 

--- a/test/acceptance/helpers/proxy.js
+++ b/test/acceptance/helpers/proxy.js
@@ -50,7 +50,7 @@ export function createApiProxy() {
   app.all('*', (req, res, next) => {
     let path = req.path.replace(/\/$/, '')
     requests[path] = requests[path] || []
-    requests[path].push(req)
+    requests[path].push({ requestDate: new Date(), ...req })
     next()
   })
 


### PR DESCRIPTION
## What is this? 

The title is a mouthful, that's for sure. If the child process spawned by agent in `exec` exits while snapshots are processing, it's possible for snapshots to be added to a _finalizing_ build. This will break the rendering pipeline for that build. 

## Approach

First up was to write an acceptance test that reproduces this behavior. The easiest way would be to have a PercyScript file that loops through snapshots and throws an exception while taking snapshots. Then assert to make sure no snapshots were added to to the build _after_ we've finalized the build. 

Quick solution: As soon as `handleSnaphshot` is called, add a promise to the `snapshotCreationPromises` array. That way any deferred work can still be awaited on (when we're stopping agent).

Better (future) solution: After finalize is called for a build, no more snapshot or resource requests should be uploaded. This might require more of a sweeping change to how services are interconnected yet decoupled from command classes.

## TODOs

- [x] Assert on `waiting for x snapshots` stdout 
- [x] Investigate integration test issues 