### PR TITLE
build: start command acceptance

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -69,6 +69,7 @@ export class AgentService {
       await this.snapshotService.assetDiscoveryService.teardown()
     }
 
+    new ProcessService().cleanup()
     await this.buildService.finalize()
     if (this.server) { await this.server.close() }
   }
@@ -157,7 +158,6 @@ export class AgentService {
 
   private async handleStop(_: express.Request, response: express.Response) {
     await this.stop()
-    new ProcessService().cleanup()
     return response.json({ success: true })
   }
 

--- a/test/acceptance/exec.test.js
+++ b/test/acceptance/exec.test.js
@@ -3,7 +3,6 @@ import expect from 'expect'
 import { when } from 'interactor.js'
 
 import {
-  launch,
   run,
   setupApiProxy,
   setupDummyApp
@@ -13,9 +12,10 @@ describe('percy exec', () => {
   let proxy = setupApiProxy()
 
   it('warns when PERCY_TOKEN is missing', async () => {
-    let [stdout, stderr] = await run('percy exec -- echo test', { PERCY_TOKEN: '' })
+    let [stdout, stderr, code] = await run('percy exec -- echo test', { PERCY_TOKEN: '' })
     expect(stderr).toHaveEntry('Warning: Skipping visual tests. PERCY_TOKEN was not provided.')
     expect(stdout).toHaveEntry('test')
+    expect(code).toEqual(0)
   })
 
   it('logs a message when missing a command', async () => {

--- a/test/acceptance/helpers/index.js
+++ b/test/acceptance/helpers/index.js
@@ -1,4 +1,4 @@
 export { default as setupDummyApp } from './dummy'
 export { default as setupApiProxy } from './proxy'
 export { default as run } from './run'
-export { default as launch } from './snapshot'
+export { default as launch, agentIsReady } from './snapshot'

--- a/test/acceptance/start.test.js
+++ b/test/acceptance/start.test.js
@@ -18,15 +18,14 @@ describe('percy start', () => {
   })
 
   it('starts the agent server and stops it when the process is killed', async () => {
-    let start = run('percy start')
-
+    let start = run('percy start', true)
     // kill the process as soon as it's ready
-    await agentIsReady()
-    // puppeteer will complain if we kill the process while it is launching chrome; wait 100ms
-    setTimeout(() => start.child.kill(), 100)
+    await when(() => expect(start.stdio[1]).toHaveEntry('percy is ready.'), 3000)
+    require('child_process').execSync(`kill ${start.child.pid}`)
 
-    let [stdout, stderr] = await start
+    let [stdout, stderr, code] = await start
 
+    console.log('finished!', code)
     expect(stderr).toHaveLength(0)
     expect(stdout).toHaveEntries([
       '[percy] created build #4: <<build-url>>',

--- a/test/acceptance/start.test.js
+++ b/test/acceptance/start.test.js
@@ -1,0 +1,41 @@
+import expect from 'expect'
+import { when } from 'interactor.js'
+
+import {
+  run,
+  setupApiProxy,
+  agentIsReady
+} from './helpers'
+
+describe('percy start', () => {
+  let proxy = setupApiProxy()
+
+  it('warns and exits when PERCY_TOKEN is missing', async () => {
+    let [stdout, stderr, code] = await run('percy start', { PERCY_TOKEN: '' })
+    expect(stderr).toHaveEntry('Warning: Skipping visual tests. PERCY_TOKEN was not provided.')
+    expect(stdout).toHaveLength(0)
+    expect(code).toBe(0)
+  })
+
+  it('starts the agent server and stops it when the process is killed', async () => {
+    let start = run('percy start')
+
+    // kill the process as soon as it's ready
+    await agentIsReady()
+    // puppeteer will complain if we kill the process while it is launching chrome; wait 100ms
+    setTimeout(() => start.child.kill(), 100)
+
+    let [stdout, stderr] = await start
+
+    expect(stderr).toHaveLength(0)
+    expect(stdout).toHaveEntries([
+      '[percy] created build #4: <<build-url>>',
+      '[percy] percy has started.',
+      '[percy] percy is ready.',
+      '[percy] stopping percy...',
+      '[percy] waiting for 0 snapshots to complete...',
+      '[percy] done.',
+      '[percy] finalized build #4: <<build-url>>',
+    ])
+  })
+})


### PR DESCRIPTION
## Purpose

Sets up initial acceptance tests for the `start` command

## Approach

Updated the `run` helper to accept an additional argument to enable piping output to the current process for debugging. A final arg of `true` to the `run` helper will set up the pipe for the parent process. The sdio of the child process is still captured during debugging.

Added two basic acceptance tests for `start`:

- A warning is logged when there is no PERCY_TOKEN
- The server stops and finalizes the build when the process is killed

I initially added a third test, to test that `--detached` works as expected. However, I discovered that it will save log info to a hardcoded path in the cwd, which isn't ideal for testing. Even if this was made configurable, using `--detached` has other consequences that prevent it from connecting with the local test proxy (haven't debugged fully). Finally, while attempting to test this, I fixed an issue where the PID file was never properly cleaned up if the process was killed.

Given all of the issues with `--detached`, it might be better to just recommend using the built-in `&` to run processes in the background. Logs can be easily capture by adding `> some-file.log` to the CLI. The only change needed to support `&` would be to remove the PID file completely and have the `stop` command do a health check rather than check for a local PID file.

#### Unrelated:

Also added a test for the exec exit code when PERCY_TOKEN is missing