### PR TITLE
fix: assets loading issues

### DIFF
--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -90,6 +90,12 @@ export default class ResponseService extends PercyClientService {
       return this.handleRedirectResouce(url, redirectedURL, request.headers(), width, logger)
     }
 
+    if (request.resourceType() === 'other' && (await response.text()).length === 0) {
+      // Skip empty other resource types (browser resource hints)
+      logger.debug(`Skipping [is_empty_other]: ${request.url()}`)
+      return
+    }
+
     return this.handlePuppeteerResource(url, response, width, logger)
   }
 


### PR DESCRIPTION
Add check to ensure that requests with 'other' resource type; with an
empty response body are skipped.

The `shouldRequestResolve` in `asset-discovery-service` is used to capture
resource hints in older chromium versions. Cypress versions < 3.5.0 used
chrome 61 whilst above versions have upgraded to 73.

In chrome 61 the resource hint type requests recieved the request
purpose in he header. In future versions, confirmed 73+, this header is
not sent.

In newer chrome versions we can check the request `resourceType`; if of
type 'other' and with an empty response body we can skip the handling of
this request.