### PR TITLE
fix: don't log success on error

### DIFF
--- a/src/services/build-service.ts
+++ b/src/services/build-service.ts
@@ -35,7 +35,7 @@ export default class BuildService extends PercyClientService {
       await this.percyClient.finalizeBuild(this.buildId)
       this.logEvent('finalized')
     } catch (err) {
-      console.log(err)
+      logError(err)
     }
   }
 

--- a/src/services/build-service.ts
+++ b/src/services/build-service.ts
@@ -31,8 +31,12 @@ export default class BuildService extends PercyClientService {
   async finalize() {
     if (!this.buildId) { return }
 
-    await this.percyClient.finalizeBuild(this.buildId).catch(logError)
-    this.logEvent('finalized')
+    try {
+      await this.percyClient.finalizeBuild(this.buildId)
+      this.logEvent('finalized')
+    } catch (err) {
+      console.log(err)
+    }
   }
 
   async finalizeAll(): Promise<any> {

--- a/test/acceptance/exec.test.js
+++ b/test/acceptance/exec.test.js
@@ -92,6 +92,16 @@ describe('percy exec', () => {
     expect(proxy.requests['/builds/123/finalize']).toHaveLength(1)
   })
 
+  it('logs finalization errors', async () => {
+    proxy.mock('/builds/:id/finalize', () => [404, { success: false }])
+
+    let [stdout, stderr] = await run('percy exec -- echo test')
+
+    expect(stdout).toHaveEntry('[percy] created build #4: <<build-url>>')
+    expect(stderr).toHaveEntry('[percy] StatusCodeError 404 - {"success":false}')
+    expect(stdout).not.toHaveEntry('[percy] finalized build #4: <<build-url>>')
+  })
+
   describe('with snapshots', () => {
     let dummy = setupDummyApp()
 


### PR DESCRIPTION
## Purpose

Even if the finalize request fails, we currently print a `finalized build` message (which is not true)

## Approach

@Robdel12 did the fix, I added a test and sent the error to stderr rather than stdout.

Previously, we were `catch`ing a promise and _then_ logging "successfully." Since the promise thinks the error is "handled" it allows execution to continue. Moving `catch` to be after `then` rather than before will correctly log on a successful response only. Also, rather than mixing `async`/`await` and `then/catch`, this change strictly sticks to `async`/`await` (and uses a `try`/`catch` block instead of promise methods).