### PR TITLE
fix: add context to log output on finalize error

### DIFF
--- a/src/services/build-service.ts
+++ b/src/services/build-service.ts
@@ -35,6 +35,7 @@ export default class BuildService extends PercyClientService {
       await this.percyClient.finalizeBuild(this.buildId)
       this.logEvent('finalized')
     } catch (err) {
+      logger.error('error finalizing build')
       logError(err)
     }
   }

--- a/test/acceptance/exec.test.js
+++ b/test/acceptance/exec.test.js
@@ -98,6 +98,7 @@ describe('percy exec', () => {
     let [stdout, stderr] = await run('percy exec -- echo test')
 
     expect(stdout).toHaveEntry('[percy] created build #4: <<build-url>>')
+    expect(stderr).toHaveEntry('[percy] error finalizing build')
     expect(stderr).toHaveEntry('[percy] StatusCodeError 404 - {"success":false}')
     expect(stdout).not.toHaveEntry('[percy] finalized build #4: <<build-url>>')
   })


### PR DESCRIPTION
## Purpose

Merged #435 a little fast for some PR feedback

## Approach

Adds some context to the log output on finalize as @timhaines suggested.