### PR TITLE
fix: Inject Percy CSS before very last closing body tag

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -134,7 +134,7 @@ export class AgentService {
     // serving a response for this CSS we're injecting into the DOM
     if (snapshotOptions.percyCSS) {
       const cssLink = `<link data-percy-specific-css rel="stylesheet" href="/${percyCSSFileName}" />`
-      domSnapshot = domSnapshot.replace(/<\/body>/i, cssLink + '$&')
+      domSnapshot = domSnapshot.replace(/(<\/body>)(?!.*\1)/is, cssLink + '$&')
     }
 
     resources = resources.concat(

--- a/test/integration/testcases/percy-specific-css.html
+++ b/test/integration/testcases/percy-specific-css.html
@@ -3,6 +3,7 @@
     <title>Percy Specific CSS testing</title>
   </head>
   <body>
+    <script> var test = "</body>" </script>
     <div class="percy-only-css-snapshot"></div>
     <div class="percy-only-css-global"></div>
   </body>


### PR DESCRIPTION
## Purpose

We currently loosely inject the Percy CSS style tag right before _a_ closing `</body>` tag. When the page contains some other text that also has a `</body>` (could be a string in JS), the Percy CSS style tag gets incorrectly injected into the wrong place.

## Approach

Tighten the regular expression to match only the last instance of `</body>` which should appear at the end of the document.

`(<\/body>)` matches the tag in a capturing group  
`(?!.*\1)` negative lookahead ensures there are no other matching groups after the last one  
`/is` will match case insensitive (`i`) and allow `.` to match newlines (`s`)