### PR TITLE
fix: Add timestamps to logs

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -4,7 +4,7 @@ import * as puppeteer from 'puppeteer'
 import { AssetDiscoveryConfiguration } from '../configuration/asset-discovery-configuration'
 import { DEFAULT_CONFIGURATION } from '../configuration/configuration'
 import { SnapshotOptions } from '../percy-agent-client/snapshot-options'
-import { logError, profile } from '../utils/logger'
+import { addLogDate, logError, profile } from '../utils/logger'
 import { cacheResponse, getResponseCache } from '../utils/response-cache'
 import waitForNetworkIdle from '../utils/wait-for-network-idle'
 import PercyClientService from './percy-client-service'
@@ -102,7 +102,7 @@ export class AssetDiscoveryService extends PercyClientService {
 
     rootResourceUrl = this.parseRequestPath(rootResourceUrl)
 
-    logger.debug(`discovering assets for URL: ${rootResourceUrl}`)
+    logger.debug(addLogDate(`discovering assets for URL: ${rootResourceUrl}`))
 
     const {
       enableJavaScript = false,
@@ -177,7 +177,7 @@ export class AssetDiscoveryService extends PercyClientService {
     requestHeaders: any = {},
     logger: any,
   ): Promise<any[]> {
-    logger.debug(`discovering assets for width: ${width}`)
+    logger.debug(addLogDate(`discovering assets for width: ${width}`))
 
     profile('--> assetDiscoveryService.pool.acquire', { url: rootResourceUrl })
     const page = await pool.acquire()
@@ -208,7 +208,7 @@ export class AssetDiscoveryService extends PercyClientService {
         }
 
         if (this.configuration['cache-responses'] === true && getResponseCache(requestUrl)) {
-          logger.debug(`Asset cache hit for ${requestUrl}`)
+          logger.debug(addLogDate(`Asset cache hit for ${requestUrl}`))
           await request.respond(getResponseCache(requestUrl))
 
           return
@@ -242,13 +242,13 @@ export class AssetDiscoveryService extends PercyClientService {
         promise.catch(logError)
         maybeResourcePromises.push(promise)
       } else {
-        logger.debug(`No response for ${request.url()}. Skipping.`)
+        logger.debug(addLogDate(`No response for ${request.url()}. Skipping.`))
       }
     })
 
     // Debug log failed requests.
     page.on('requestfailed', async (request) => {
-      logger.debug(`Failed to load ${request.url()} : ${request.failure()!.errorText}}`)
+      logger.debug(addLogDate(`Failed to load ${request.url()} : ${request.failure()!.errorText}}`))
     })
 
     let maybeResources: any[] = []

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { logError, profile } from '../utils/logger'
+import { addLogDate, logError, profile } from '../utils/logger'
 import PercyClientService from './percy-client-service'
 
 export default class ResourceService extends PercyClientService {
@@ -16,7 +16,7 @@ export default class ResourceService extends PercyClientService {
     const sha = path.basename(copyFilePath)
     const resourceUrl = responseUrl
 
-    logger.debug('creating resource')
+    logger.debug(addLogDate('creating resource'))
     logger.debug(`-> response: ${responseUrl}`)
     logger.debug(`-> copyFilePath: ${copyFilePath}`)
     logger.debug(`-> resourceUrl: ${resourceUrl}`)

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,6 +3,10 @@ import * as winston from 'winston'
 
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info'
 
+export function addLogDate(log: string) {
+  return `${log} | ${new Date().toString()}`
+}
+
 function createConsoleTransport() {
   return new winston.transports.Console({
     level: LOG_LEVEL,

--- a/src/utils/response-cache.ts
+++ b/src/utils/response-cache.ts
@@ -1,4 +1,5 @@
 import { Response } from 'puppeteer'
+import { addLogDate } from './logger'
 let responseCache = {} as any
 
 /**
@@ -13,7 +14,7 @@ export async function cacheResponse(response: Response, logger: any) {
   const statusCode = response.status()
 
   if (!!responseCache[responseUrl]) {
-    logger.debug(`Asset already in cache ${responseUrl}`)
+    logger.debug(addLogDate(`Asset already in cache ${responseUrl}`))
     return
   }
 
@@ -30,9 +31,9 @@ export async function cacheResponse(response: Response, logger: any) {
       body: buffer,
     }
 
-    logger.debug(`Added ${responseUrl} to asset discovery cache`)
+    logger.debug(addLogDate(`Added ${responseUrl} to asset discovery cache`))
   } catch (error) {
-    logger.debug(`Could not cache response ${responseUrl}: ${error}`)
+    logger.debug(addLogDate(`Could not cache response ${responseUrl}: ${error}`))
   }
 }
 


### PR DESCRIPTION
## What is this?

This adds date timestamps to asset discovery logs. Ideally this would be implemented as its own transport for winston, but that would require a lot of refactoring due to how we're passing around the logger. 

This will have to do until we can refactor to the right way. 