### PR TITLE
fix: Add timestamps to error logs

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -266,8 +266,8 @@ export class AssetDiscoveryService extends PercyClientService {
       maybeResources = await Promise.all(maybeResourcePromises)
       profile('--> assetDiscoveryServer.waitForResourceProcessing')
     } catch (error) {
-      logger.error(`${error.name} ${error.message}`)
-      logger.debug(error)
+      logger.error(addLogDate(`${error.name} ${error.message}`))
+      logger.debug(addLogDate(error))
     }
 
     // always release the page from the pool

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -29,8 +29,8 @@ export function profile(id: string, meta?: any): winston.Logger | undefined {
 }
 
 export function logError(error: any) {
-  logger.error(`${error.name} ${error.message}`)
-  logger.debug(error)
+  logger.error(addLogDate(`${error.name} ${error.message}`))
+  logger.debug(addLogDate(error))
 }
 
 export function createFileLogger(filename: string) {


### PR DESCRIPTION
## What is this?

I forgot to add the timestamp to error logs in #455. This adds those, since they're pretty valuable. 