### PR TITLE
fix: clamp image dimensions to min and max for snapshot width and minHeight options

### DIFF
--- a/src/services/image-snapshot-service.ts
+++ b/src/services/image-snapshot-service.ts
@@ -93,8 +93,9 @@ export default class ImageSnapshotService extends PercyClientService {
   ): Promise<any> {
     return this.percyClient.createSnapshot(this.buildId, resources, {
       name,
-      widths: [width],
-      minimumHeight: height,
+      // clamp between 10px - 2000px
+      widths: [Math.max(10, Math.min(width, 2000))],
+      minimumHeight: Math.max(10, Math.min(height, 2000)),
       clientInfo: 'percy-upload',
     }).then(async (response: any) => {
       await this.percyClient.uploadMissingResources(this.buildId, response, resources)


### PR DESCRIPTION
## Purpose

#459 brought to light that sometimes image dimensions might be outside of the bounds of our min and max for snapshots.

## Approach

Clamp both width and height to between 10px - 2000px, but for snapshot options `widths` and `minHeight` only as the image in the DOM should contain the correct width and height.

When we render on our side, the full image should still be captured.

### TODO

- [ ] Should I add a matrix of images to test this? 
  - [ ] Image width < 10px
  - [ ] Image width > 2000px
  - [ ] Image height < 10px
  - [ ] Image height > 2000px
  - [ ] Image width < 10px, height < 10px
  - [ ] Image width < 10px, height > 2000px
  - [ ] Image width > 2000px, height < 10px
  - [ ] Image width > 2000px, height > 2000px