### PR TITLE
feat: iframe serialization

### DIFF
--- a/test/unit/tslint.json
+++ b/test/unit/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tslint.json",
+  "rules": {
+    "no-unused-expression": false
+  }
+}


### PR DESCRIPTION
## Purpose

Currently, we only capture iframes during the asset discovery process. In which we only capture the response of the `src` attribute. If an iframe has been interacted with, navigated within, or built with JavaScript, we cannot properly capture that iframe.

This PR aims to solve those limitations

## Approach

During DOM serialization, we can retrieve the DOM of an iframe using `iframe.contentDocument`. We can then recursively serialize that DOM, and once serialized set the content as a `srcdoc` attribute. The `src` attribute is then removed since it is no longer needed and might cause other issues.

While dealing with iframes, we can also remove iframes from the `<head>`. These iframes typically have no visual presentation and when they do, they often break pages since rerendering causes the browser to "fix" the `<head>` and pushes everything from the iframe down into an implicit `<body>` (and ignore the explicit `<body>`).

The `contentDocument` property returns `null` for iframes with security restrictions (CORS), so we have no way to serialize those iframes. We also do not want to serialize iframes that have not finished loading (even with CORS, you can access the DOM before it loads and incorrectly serialize an empty DOM). Firefox does not trigger load-related properties for iframes built with JS, so those iframes are always serialized (as long as JS is not enabled).

There are simple tests included here, but as a complex example I manually tested this on a live site where the iframe has internal navigation on form submission. [Results here](https://percy.io/percy/wil-test-bed/builds/4254676).