### PR TITLE
feat: Enable asset discovery network caching by default

### DIFF
--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -31,7 +31,7 @@ export default class Exec extends PercyCommand {
     'cache-responses': flags.boolean({
       description: [
         `[default: ${DEFAULT_CONFIGURATION.agent['asset-discovery']['cache-responses']}]`,
-        'Enable caching network responses for asset discovery (experimental)',
+        'Caches successful network responses in asset discovery',
       ].join(' '),
     }),
     'port': flags.integer({

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -27,7 +27,7 @@ export const DEFAULT_CONFIGURATION: Configuration = {
       'network-idle-timeout': 50, // ms
       'page-pool-size-min': 1, // pages
       'page-pool-size-max': 5, // pages
-      'cache-responses': false,
+      'cache-responses': true,
     },
   },
   'static-snapshots': {


### PR DESCRIPTION
## What is this?

We have tried this out in support for the past couple months with _great_ success. We're confident enough in this approach to now enable it by default for everyone, which should make the asset discovery process much more reliable and faster.
