### PR TITLE
feat: add meta information to healthcheck endpoint

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -165,6 +165,12 @@ export class AgentService {
   }
 
   private async handleHealthCheck(_: express.Request, response: express.Response) {
-    return response.json({ success: true })
+    return response.json({
+      success: true,
+      build: {
+        number: this.buildService.buildNumber,
+        url: this.buildService.buildUrl,
+      },
+    })
   }
 }


### PR DESCRIPTION
## Purpose

It might be useful for third part SDKs or even our own SDKs in the future to be able to query the server for some meta information. For now this is limited to build number and URL but could be expanded to include SDK options passed through from the CLI or config file.

## Approach

Add meta to the healthcheck response and test it.

I noticed that other requests in this file were not awaited on, so they were updated accordingly.