### PR TITLE
fix: Log DOM transform error so it doesn't end up as [Object object]

### DIFF
--- a/src/percy-agent-client/dom.ts
+++ b/src/percy-agent-client/dom.ts
@@ -42,7 +42,8 @@ class DOM {
       try {
         dom = this.options.domTransformation(dom)
       } catch (error) {
-        console.error('Could not transform the dom: ', error)
+        console.error('Could not transform the dom:')
+        console.error(error)
       }
     }
 

--- a/test/unit/percy-agent-client/dom.test.ts
+++ b/test/unit/percy-agent-client/dom.test.ts
@@ -104,7 +104,7 @@ describe('DOM -', () => {
       expect(consoleStub.called).to.equal(false)
       // invoke the transform function again to try and remove a non-existent element
       expect(dom.snapshotString()).to.contain('Hello DOM testing')
-      expect(consoleStub.calledOnce).to.equal(true)
+      expect(consoleStub.calledTwice).to.equal(true)
     })
   })
 


### PR DESCRIPTION
## What is this?

This should hopefully prevent logs like: 

```
browser log: |
ERROR: Could not transform the dom: [object Object]
```

[By using the single arg form of `console.error`](https://developer.mozilla.org/en-US/docs/Web/API/Console/error) it should properly stringify the error & stacktrace for the console. 