### PR TITLE
fix: Call `toString` on error

### DIFF
--- a/src/percy-agent-client/dom.ts
+++ b/src/percy-agent-client/dom.ts
@@ -42,8 +42,7 @@ class DOM {
       try {
         dom = this.options.domTransformation(dom)
       } catch (error) {
-        console.error('Could not transform the dom:')
-        console.error(error)
+        console.error('Could not transform the dom: ', error.toString())
       }
     }
 

--- a/test/unit/percy-agent-client/dom.test.ts
+++ b/test/unit/percy-agent-client/dom.test.ts
@@ -104,7 +104,7 @@ describe('DOM -', () => {
       expect(consoleStub.called).to.equal(false)
       // invoke the transform function again to try and remove a non-existent element
       expect(dom.snapshotString()).to.contain('Hello DOM testing')
-      expect(consoleStub.calledTwice).to.equal(true)
+      expect(consoleStub.calledOnce).to.equal(true)
     })
   })
 


### PR DESCRIPTION
Issue #478 attempted to break the error apart to perserve the stacktrace, but it
looks like it's failing to produce the error message at all (depedning on the
test framework/logging setup).

We're going to call `.toString` on the error to print the message. If the user
wants the stack trace, they will need to open the browser and place a breakpoint
on the error log.