### PR TITLE
fix: Log out snapshot options in debug logs

### DIFF
--- a/src/services/agent-service.ts
+++ b/src/services/agent-service.ts
@@ -109,6 +109,12 @@ export class AgentService {
       minHeight: request.body.minHeight || this.snapshotConfig['min-height'],
     }
 
+    snapshotLogger.debug(`-> widths: ${snapshotOptions.widths}`)
+    snapshotLogger.debug(`-> minHeight: ${snapshotOptions.minHeight}`)
+    snapshotLogger.debug(`-> enableJavaScript: ${snapshotOptions.enableJavaScript}`)
+    snapshotLogger.debug(`-> requestHeaders: ${snapshotOptions.requestHeaders}`)
+    snapshotLogger.debug(`-> percyCSS: ${snapshotOptions.percyCSS}`)
+
     let domSnapshot = request.body.domSnapshot
 
     if (domSnapshot.length > Constants.MAX_FILE_SIZE_BYTES) {


### PR DESCRIPTION
Super helpful for debugging:

```bash
[percy] -> widths: 375,1200
[percy] -> minHeight: 1024
[percy] -> enableJavaScript: undefined
[percy] -> requestHeaders: undefined
[percy] -> percyCSS: .percy-only-css-global {
  height: 300px;
  width: 300px;
  background-color: blue;
}```