### PR TITLE
build: Add Home URL and Source Code URL + Fix

### DIFF
--- a/.circleci/orb.yml
+++ b/.circleci/orb.yml
@@ -1,7 +1,10 @@
 version: "2.1"
 description: > 
   Workflow for running Percy builds in parallel. Finalize is commonly used for parallelized builds, especially when the number of parallelized processes is unknown.
-  Your token will be read from environment variable "PERCY_TOKEN". Source Code: https://github.com/percy/percy-agent/
+  Your token will be read from environment variable "PERCY_TOKEN".
+display:
+  home_url: https://percy.io/
+  source_url: https://github.com/percy/percy-agent/
 
 examples:
   finalize_all_percy_builds:
@@ -10,7 +13,7 @@ examples:
       version: 2.1
 
       orbs:
-        percy: percy/agent@1.0.0
+        percy: percy/agent@x.y
 
       workflows:
         percy_finalize_all:
@@ -37,7 +40,7 @@ commands:
         type: env_var_name
         default: PERCY_TOKEN
     steps:
-      - run: PERCY_TOKEN=<< parameters.percy_token >> percy finalize --all
+      - run: PERCY_TOKEN=$<< parameters.percy_token >> percy finalize --all
 
 jobs:
   finalize_all:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.

Fix: On line 43 - The env_var_name is a string that represents the name of the env var. the "$" is still required to transform it into an env var at the shell.