### PR TITLE
feat: snapshot and upload --dry-run flag

### DIFF
--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -21,21 +21,25 @@ export default class Upload extends Command {
   ]
 
   static flags = {
-    files: flags.string({
+    'files': flags.string({
       char: 'f',
       description: [
         `[default: ${DEFAULT_CONFIGURATION['image-snapshots'].files}]`,
         'Glob or comma-seperated string of globs for matching the files and directories to snapshot.',
       ].join(' '),
     }),
-    ignore: flags.string({
+    'ignore': flags.string({
       char: 'i',
       description: [
         `[default: ${DEFAULT_CONFIGURATION['image-snapshots'].ignore}]`,
         'Glob or comma-seperated string of globs for matching the files and directories to ignore.',
       ].join(' '),
     }),
-    config: flags.string({
+    'dry-run': flags.boolean({
+      char: 'd',
+      description: 'Print the list of images to upload without uploading them',
+    }),
+    'config': flags.string({
       char: 'c',
       description: 'Path to percy config file',
     }),
@@ -59,6 +63,6 @@ export default class Upload extends Command {
 
     // upload snapshot images
     const imageSnapshotService = new ImageSnapshotService(configuration['image-snapshots'])
-    await imageSnapshotService.snapshotAll()
+    await imageSnapshotService.snapshotAll({ dry: flags['dry-run'] })
   }
 }

--- a/src/services/image-snapshot-service.ts
+++ b/src/services/image-snapshot-service.ts
@@ -109,7 +109,7 @@ export default class ImageSnapshotService extends PercyClientService {
     }).catch(logError)
   }
 
-  async snapshotAll() {
+  async snapshotAll({ dry = false }: { dry?: boolean } = {}) {
     const globs = parseGlobs(this.configuration.files)
     const ignore = parseGlobs(this.configuration.ignore)
     const paths = await globby(globs, { cwd: this.configuration.path, ignore })
@@ -117,8 +117,12 @@ export default class ImageSnapshotService extends PercyClientService {
 
     if (!paths.length) {
       logger.error(`no matching files found in '${this.configuration.path}''`)
-      logger.info('exiting')
       return process.exit(1)
+    }
+
+    if (dry) {
+      console.log(paths.join('\n'))
+      return
     }
 
     await this.buildService.create()

--- a/test/unit/commands/upload.test.ts
+++ b/test/unit/commands/upload.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@oclif/test'
+import { describe } from 'mocha'
+import * as sinon from 'sinon'
+import Upload from '../../../src/commands/upload'
+import ImageSnapshotService from '../../../src/services/image-snapshot-service'
+import { captureStdErr, captureStdOut } from '../helpers/stdout'
+import chai from '../support/chai'
+
+describe('upload', () => {
+  describe('#run', () => {
+    const sandbox = sinon.createSandbox()
+
+    afterEach(() => {
+      sandbox.restore()
+      // restore token to fake value
+      process.env.PERCY_TOKEN = 'abc'
+    })
+
+    function ImageSnapshotServiceStub(): ImageSnapshotService {
+      const imageSnapshotService = ImageSnapshotService.prototype as ImageSnapshotService
+      sandbox.stub(imageSnapshotService, 'snapshotAll')
+
+      return imageSnapshotService
+    }
+
+    it('starts the static image service', async () => {
+      const imageSnapshotServiceStub = ImageSnapshotServiceStub()
+
+      const stdout = await captureStdOut(async () => {
+        await Upload.run(['.'])
+      })
+
+      chai.expect(imageSnapshotServiceStub.snapshotAll).to.have.callCount(1)
+      chai.expect(stdout).not.to.match(/\[percy\] uploading snapshots of static images./)
+    })
+
+    it('warns about PERCY_TOKEN not being set and exits gracefully', async () => {
+      process.env.PERCY_TOKEN = ''
+
+      const stderr = await captureStdErr(async () => {
+        await Upload.run(['.'])
+      })
+
+      chai.expect(stderr).to.match(/Warning: PERCY_TOKEN was not provided\./)
+    })
+
+    describe('with --dry-run', () => {
+      it('does not upload snapshots', async () => {
+        const imageSnapshotServiceStub = ImageSnapshotServiceStub()
+
+        const stdout = await captureStdOut(async () => {
+          await Upload.run(['./test/integration/test-static-images', '--dry-run'])
+        })
+
+        chai.expect(imageSnapshotServiceStub.snapshotAll).to.be.calledWith({ dry: true })
+        chai.expect(stdout).not.to.match(/\[percy\] uploading snapshots of static images./)
+      })
+
+      it('prints paths to images matching the provided options', async () => {
+        const stdout = await captureStdOut(async () => {
+          await Upload.run([
+            './test/integration/test-static-images',
+            '--files=percy*',
+            '--ignore=*.jpg',
+            '--dry-run',
+          ])
+        })
+
+        chai.expect(stdout).to.equal([
+          'percy logo.png',
+        ].join('\n') + '\n')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Purpose

When honing in your file globs for the `upload` and `snapshot` commands, it can be exhaustive to keep creating new Percy builds. This adds a `--dry-run` (or `-d`) flag to both commands which will not create a new Percy build and print the list of matching paths.

## Approach

For the `snapshot` command, the snapshot service is responsible for parsing the paths. At that point in the command execution, a build has already been created and the local server started. The resulting paths also have the localhost URL and port attached which is not desirable for printing just the paths. For this command, the glob parsing was copy and pasted into another command method which is called when `--dry-run` is provided.

For the `upload` command, the build is created after glob parsing. So we can safely handle the `--dry-run` parameter in the `snapshotAll` method and exit early after printing matching paths.

There were no unit tests for the `upload` command so the `snapshot` command tests were copied over and adjusted accordingly.