### PR TITLE
fix: snapshot & upload sort dry-run output

### DIFF
--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -132,6 +132,6 @@ export default class Snapshot extends PercyCommand {
     const ignore = parseGlobs(configuration['ignore-files'])
     const paths = await globby(globs, { cwd: configuration.path, ignore })
 
-    console.log(paths.map((p) => configuration['base-url'] + p).join('\n'))
+    console.log(paths.map((p) => configuration['base-url'] + p).sort().join('\n'))
   }
 }

--- a/src/services/image-snapshot-service.ts
+++ b/src/services/image-snapshot-service.ts
@@ -112,7 +112,7 @@ export default class ImageSnapshotService extends PercyClientService {
   async snapshotAll({ dry = false }: { dry?: boolean } = {}) {
     const globs = parseGlobs(this.configuration.files)
     const ignore = parseGlobs(this.configuration.ignore)
-    const paths = await globby(globs, { cwd: this.configuration.path, ignore })
+    const paths = (await globby(globs, { cwd: this.configuration.path, ignore })).sort()
     let error
 
     if (!paths.length) {


### PR DESCRIPTION
## Purpose

Tests show that dry run output can sometimes be flakey due to sort order.

## Approach

Rather than fix the test, this sorts the output. Having the output be sorted will help people iterate on globs so you don't have to search the list to find if something was selected by the glob or not.

Tests were already assuming the output was sorted, so this should result in no more flakes for this test.