### PR TITLE
fix: Up default network idle timeout to 125

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ commands:
   unit_client_acceptance_integration:
     steps:
       - run:
+          name: Lint
+          command: yarn lint
+      - run:
           name: Unit tests
           command: |
             mkdir -p reports

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ OPTIONS
   -c, --config=config                              Path to percy config file
   -h, --allowed-hostname=allowed-hostname          Allowable hostname(s) to capture assets from
   -p, --port=port                                  [default: 5338] Port
-  -t, --network-idle-timeout=network-idle-timeout  [default: 50] Asset discovery network idle timeout (in milliseconds)
+  -t, --network-idle-timeout=network-idle-timeout  [default: 125] Asset discovery network idle timeout (in milliseconds)
 
   --cache-responses                                [default: true] Caches successful network responses in asset
                                                    discovery
@@ -57,6 +57,8 @@ EXAMPLES
   $ percy exec -- echo "percy is running around this echo command"
   $ percy exec -- bash -c "echo foo && echo bar"
 ```
+
+_See code: [dist/commands/exec.ts](https://github.com/percy/percy-agent/blob/v0.26.1/dist/commands/exec.ts)_
 
 ## `percy finalize`
 
@@ -73,6 +75,8 @@ EXAMPLE
   $ percy finalize --all
   [percy] Finalized parallel build.
 ```
+
+_See code: [dist/commands/finalize.ts](https://github.com/percy/percy-agent/blob/v0.26.1/dist/commands/finalize.ts)_
 
 ## `percy help [COMMAND]`
 
@@ -121,13 +125,15 @@ OPTIONS
   -s, --snapshot-files=snapshot-files              [default: **/*.html,**/*.htm] Glob or comma-seperated string of globs
                                                    for matching the files and directories to snapshot.
 
-  -t, --network-idle-timeout=network-idle-timeout  [default: 50] Asset discovery network idle timeout (in milliseconds)
+  -t, --network-idle-timeout=network-idle-timeout  [default: 125] Asset discovery network idle timeout (in milliseconds)
 
 EXAMPLES
   $ percy snapshot _site/
   $ percy snapshot _site/ --base-url "/blog/"
   $ percy snapshot _site/ --ignore-files "/blog/drafts/**"
 ```
+
+_See code: [dist/commands/snapshot.ts](https://github.com/percy/percy-agent/blob/v0.26.1/dist/commands/snapshot.ts)_
 
 ## `percy upload [UPLOADDIRECTORY]`
 
@@ -154,4 +160,6 @@ EXAMPLES
   $ percy upload _images/
   $ percy upload _images/ --files **/*.png
 ```
+
+_See code: [dist/commands/upload.ts](https://github.com/percy/percy-agent/blob/v0.26.1/dist/commands/upload.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "express-basic-auth": "^1.2.0",
     "hoxy": "^3.3.1",
     "http-proxy": "^1.18.0",
-    "husky": "^3.0.0",
     "interactor.js": "^1.3.1",
     "karma": "^4.1.0",
     "karma-chrome-launcher": "^3.0.0",
@@ -123,11 +122,6 @@
     "/dist"
   ],
   "homepage": "https://github.com/percy/percy-agent",
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn lint"
-    }
-  },
   "keywords": [
     "oclif",
     "percy",
@@ -148,7 +142,7 @@
     "build": "yarn clean && rm -rf dist && tsc && yarn build-client",
     "build-client": "webpack",
     "clean": "rm -f .oclif.manifest.json",
-    "lint": "tsc -p test/unit --noEmit && tslint -p test/unit -t stylish --fix",
+    "lint": "tsc -p test/unit --noEmit && tslint -p test/unit -t stylish",
     "postpublish": "yarn clean",
     "posttest": "yarn lint",
     "prepublishOnly": "yarn build && oclif-dev manifest && oclif-dev readme",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -24,7 +24,7 @@ export const DEFAULT_CONFIGURATION: Configuration = {
     'asset-discovery': {
       'request-headers': {},
       'allowed-hostnames': [],
-      'network-idle-timeout': 50, // ms
+      'network-idle-timeout': 125, // ms
       'page-pool-size-min': 1, // pages
       'page-pool-size-max': 5, // pages
       'cache-responses': true,

--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -249,7 +249,7 @@ export class AssetDiscoveryService extends PercyClientService {
       }
     })
 
-    const maybeResourcePromises: Array<Promise<any>> = []
+    const maybeResourcePromises: Promise<any>[] = []
     // Listen on 'requestfinished', which tells us a request completed successfully.
     // We could also listen on 'response', but then we'd have to check if it was successful.
     page.on('requestfinished', async (request) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5189,11 +5189,6 @@ get-func-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
-get-stdin@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
-  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
-
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -5683,23 +5678,6 @@ humanize-ms@^1.2.1:
   integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
   dependencies:
     ms "^2.0.0"
-
-husky@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.4.tgz#10a48ac11ab50859b0939750fa0b4e07ad0bf669"
-  integrity sha512-7Rnt8aJfy+MlV28snmYK7O7vWwtOfeVxV6KhLpUFXlmx5ukQ1nQmNUB7QsAwSgdySB5X+bm7q7JIRgazqBUzKA==
-  dependencies:
-    chalk "^2.4.2"
-    cosmiconfig "^5.2.1"
-    execa "^1.0.0"
-    get-stdin "^7.0.0"
-    is-ci "^2.0.0"
-    opencollective-postinstall "^2.0.2"
-    pkg-dir "^4.2.0"
-    please-upgrade-node "^3.2.0"
-    read-pkg "^5.1.1"
-    run-node "^1.0.0"
-    slash "^3.0.0"
 
 hyperlinker@^1.0.0:
   version "1.0.0"
@@ -8311,11 +8289,6 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-opencollective-postinstall@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
-  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
-
 opener@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
@@ -8787,13 +8760,6 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-please-upgrade-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -9612,11 +9578,6 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
-  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
-
 run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
@@ -9711,11 +9672,6 @@ semantic-release@^15.13.3:
     semver "^6.0.0"
     signale "^1.2.1"
     yargs "^15.0.1"
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## What is this?

We have made huge speed & reliability improvements to the asset discovery process. Upping the timeout to 125 for more reliable baseline asset discovery shouldn't be an issue. Especially now that asset discovery response caching is enabled by default for all builds now.