### PR TITLE
fix: Abort requests when caught in an error

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -251,6 +251,7 @@ export class AssetDiscoveryService extends PercyClientService {
         await request.continue()
       } catch (error) {
         logError(error)
+        await request.abort()
       }
     })
 


### PR DESCRIPTION
## What is this? 

If we don't respond the request, it will hang the tab. Since it errored, we should cancel it.