### PR TITLE
fix: Capture resources even when Puppeteer tab timesout

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -296,7 +296,12 @@ export class AssetDiscoveryService extends PercyClientService {
       profile('--> assetDiscoveryService.waitForNetworkIdle')
       await waitForNetworkIdle(page, this.configuration['network-idle-timeout'])
       profile('--> assetDiscoveryService.waitForNetworkIdle')
+    } catch (error) {
+      logger.error(addLogDate(`${error.name} ${error.message}`))
+      logger.debug(addLogDate(error))
+    }
 
+    try {
       profile('--> assetDiscoveryServer.waitForResourceProcessing')
       maybeResources = await Promise.all(maybeResourcePromises)
       profile('--> assetDiscoveryServer.waitForResourceProcessing')


### PR DESCRIPTION
## What is this?

This splits the try/catches up so we can still capture the discovered resources even if the `goto` to the dom snapshot times out.