### PR TITLE
fix: Properly forward headers in asset cache

### DIFF
--- a/src/utils/response-cache.ts
+++ b/src/utils/response-cache.ts
@@ -34,7 +34,15 @@ export async function cacheResponse(response: Response, logger: any) {
 
     responseCache[responseUrl] = {
       status: response.status(),
-      headers: response.headers(),
+      // CDP returns multiple headers joined by newlines, however
+      // `request.respond` (used for cached responses) will hang if there are
+      // newlines in headers. The following reduction normalizes header values
+      // as arrays split on newlines
+      headers: Object.entries(response.headers())
+        .reduce((norm, [key, value]) => (
+          // tslint:disable-next-line
+          Object.assign(norm, { [key]: value.split('\n') })
+        ), {}),
       body: buffer,
     }
 

--- a/test/unit/utils/response-cache.test.ts
+++ b/test/unit/utils/response-cache.test.ts
@@ -6,7 +6,7 @@ const logger = { debug: () => '' }
 const defaultResponse = {
   url: () => 'http://example.com/foo.txt',
   status: () => 200,
-  headers: () => 'fake headers',
+  headers: () => ({ 'fake': 'foo=bar' }),
   buffer: () => 'hello',
   text() { return this.buffer() },
   request() {
@@ -28,7 +28,7 @@ describe('Response cache util', () => {
     expect(getResponseCache('http://example.com/foo.txt')).to.eql({
       status: 200,
       body: 'hello',
-      headers: 'fake headers',
+      headers: { fake: [ 'foo=bar' ] },
     })
   })
 
@@ -38,7 +38,7 @@ describe('Response cache util', () => {
     expect(getResponseCache('http://example.com/foo.txt')).to.eql({
       status: 201,
       body: 'hello',
-      headers: 'fake headers',
+      headers: { fake: [ 'foo=bar' ] },
     })
   })
 
@@ -49,7 +49,7 @@ describe('Response cache util', () => {
     expect(getResponseCache('http://example.com/foo.txt')).to.eql({
       status: 200,
       body: 'hello',
-      headers: 'fake headers',
+      headers: { fake: [ 'foo=bar' ] },
     })
   })
 
@@ -66,5 +66,16 @@ describe('Response cache util', () => {
     await cacheResponse({ ...defaultResponse, buffer: () => '' }, logger)
 
     expect(getResponseCache('http://example.com/foo.txt')).to.eql(undefined)
+  })
+
+  it('newlines are removed from headers', async () => {
+    await cacheResponse({
+      ...defaultResponse,
+      headers: () => ({ 'fake': 'foo=bar\nthing=baz' })
+    }, logger)
+
+    expect(getResponseCache('http://example.com/foo.txt').headers).to.eql({
+      fake: [ 'foo=bar', 'thing=baz' ],
+    })
   })
 })


### PR DESCRIPTION
## What is this?

CDP returns multiple headers joined by newlines, however `request.respond` (used for cached responses) will hang if there are newlines in headers. This commit normalizes header values as arrays split on newlines.