### PR TITLE
fix(🐛): Remove inaccessible JS frames when serializing

### DIFF
--- a/test/unit/percy-agent-client/dom.test.ts
+++ b/test/unit/percy-agent-client/dom.test.ts
@@ -352,7 +352,7 @@ describe('DOM -', () => {
         const $frameInject = document.createElement('iframe') as HTMLIFrameElement
         $frameInject.setAttribute('src', 'javascript:false')
         $frameInject.setAttribute('id', 'frame-js-inject')
-        document.querySelector('.container').appendChild($frameInject)
+        document.querySelector('.container')!.appendChild($frameInject)
 
         $dom = cheerio.load(new DOM(document).snapshotString())
       })
@@ -384,7 +384,7 @@ describe('DOM -', () => {
 
       it('removes inaccessible JS iframes', () => {
         expect($dom('#frame-js-inject')).to.not.have.length
-      });
+      })
 
       it('does not serialize iframes with CORS', () => {
         expect($dom('#frame-external').attr('src')).to.equal('https://example.com')

--- a/test/unit/percy-agent-client/dom.test.ts
+++ b/test/unit/percy-agent-client/dom.test.ts
@@ -349,6 +349,11 @@ describe('DOM -', () => {
         const $frameJS = document.getElementById('frame-js-no-src') as HTMLIFrameElement
         $frameJS.contentDocument!.body.innerHTML = '<p>generated iframe</p>'
 
+        const $frameInject = document.createElement('iframe') as HTMLIFrameElement
+        $frameInject.setAttribute('src', 'javascript:false')
+        $frameInject.setAttribute('id', 'frame-js-inject')
+        document.querySelector('.container').appendChild($frameInject)
+
         $dom = cheerio.load(new DOM(document).snapshotString())
       })
 
@@ -359,6 +364,7 @@ describe('DOM -', () => {
           '<p>made with js src</p>',
           '</body></html>',
         ].join(''))
+
 
         expect($dom('#frame-js-no-src').attr('src')).to.be.undefined
         expect($dom('#frame-js-no-src').attr('srcdoc')).to.equal([
@@ -375,6 +381,10 @@ describe('DOM -', () => {
           '</body></html>$',
         ].join('')))
       })
+
+      it('removes inaccessible JS iframes', () => {
+        expect($dom('#frame-js-inject')).to.not.have.length
+      });
 
       it('does not serialize iframes with CORS', () => {
         expect($dom('#frame-external').attr('src')).to.equal('https://example.com')


### PR DESCRIPTION
## Purpose

Sometimes ads, trackers, and other external scripts may inject iframes with empty documents and a src of `javascript:false`, `javascript:null`, or `javascript:void`. During serialization, these frames might potentially be skipped and left alone if their (empty) documents are not accessible at the time of serialization. This is a problem for asset discovery when JS is disabled because the `src` attribute is still requested, however, not intercepted or resolved since JS is disabled. This causes the asset discovery browser to hang until the `page.goto` method times out.

## Approach

When the contents of the frame is not accessible in the previous if statement, JS is not enabled, and the frame in question was built with JS, the cloned frame is removed from the cloned DOM.

### Potential pitfalls

Frames that are built with JS by the user might still have these `javascript:*` src attributes. In these cases, the frames will be removed if the document is not accessible. To prevent removal, the frame should be made accessible so that it can be properly serialized.