### PR TITLE
fix(🐛): Skip all response caches when response caching is disabled

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -25,8 +25,15 @@ export class AssetDiscoveryService extends PercyClientService {
     super()
     this.browser = null
     this.pagePool = null
-    this.configuration = configuration || DEFAULT_CONFIGURATION.agent['asset-discovery']
-    this.responseService = new ResponseService(buildId, this.configuration['allowed-hostnames'])
+
+    this.configuration = configuration ||
+      DEFAULT_CONFIGURATION.agent['asset-discovery']
+
+    this.responseService = new ResponseService(
+      buildId,
+      this.configuration['allowed-hostnames'],
+      this.configuration['cache-responses']
+    )
   }
 
   async setup() {

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -21,10 +21,11 @@ export default class ResponseService extends PercyClientService {
   responsesProcessed: Map<string, string> = new Map()
   allowedHostnames: string[]
 
-  constructor(buildId: number, allowedHostnames: string[]) {
+  constructor(buildId: number, allowedHostnames: string[], cacheResponses: boolean) {
     super()
     this.resourceService = new ResourceService(buildId)
     this.allowedHostnames = allowedHostnames
+    this.cacheResponses = cacheResponses
   }
 
   shouldCaptureResource(rootUrl: string, resourceUrl: string): boolean {
@@ -51,9 +52,9 @@ export default class ResponseService extends PercyClientService {
     logger.debug(addLogDate(`processing response: ${response.url()} for width: ${width}`))
     const url = this.parseRequestPath(response.url())
 
-    // skip responses already processed
+    // skip responses already processed unless the response cache is disabled
     const processResponse = this.responsesProcessed.get(url)
-    if (processResponse) { return processResponse }
+    if (this.cacheResponses && processResponse) { return processResponse }
 
     const request = response.request()
     const parsedRootResourceUrl = new URL(rootResourceUrl)

--- a/src/services/response-service.ts
+++ b/src/services/response-service.ts
@@ -20,6 +20,7 @@ export default class ResponseService extends PercyClientService {
   resourceService: ResourceService
   responsesProcessed: Map<string, string> = new Map()
   allowedHostnames: string[]
+  cacheResponses: boolean
 
   constructor(buildId: number, allowedHostnames: string[], cacheResponses: boolean) {
     super()


### PR DESCRIPTION
## Purpose

There is a hidden layer of caching that doesn't cache request responses, but only caches processed responses. So in the past, requests might hang even though they had been processed. This processed cache is not accessible when the request is made due to the entangled nature of the various service classes and callbacks. A new response cache was created with #419 behind a flag, then once proven successful, the flag was turned on with #469. 

However, it appears that this original processed response cache is causing issues when the same URL is expected to return different assets. This should be possible by disabling the response cache, but that flag only affects the new cache.

## Approach

Pass the cache flag down to the response service so it can skip returning cached responses.

This entire layer of caching could be removed since it is redundant with the new cache. However, we could also rewrite this class to be a single helper rather than a service, but that can also be said of other service classes so I'll leave that to a future refactor.