### PR TITLE
fix(🐛): Handle page and snapshot errors

### DIFF
--- a/src/services/asset-discovery-service.ts
+++ b/src/services/asset-discovery-service.ts
@@ -215,12 +215,6 @@ export class AssetDiscoveryService extends PercyClientService {
     profile('--> assetDiscoveryService.pool.acquire', { url: rootResourceUrl })
     const page = await pool.acquire()
     profile('--> assetDiscoveryService.pool.acquire')
-    await page.setJavaScriptEnabled(enableJavaScript)
-    await page.setViewport(Object.assign(page.viewport(), { width }))
-    await page.setExtraHTTPHeaders(merge.all([
-      this.configuration['request-headers'],
-      requestHeaders,
-    ]) as {})
 
     page.on('request', async (request) => {
       const requestUrl = request.url()
@@ -296,6 +290,13 @@ export class AssetDiscoveryService extends PercyClientService {
     let maybeResources: any[] = []
 
     try {
+      await page.setJavaScriptEnabled(enableJavaScript)
+      await page.setViewport(Object.assign(page.viewport(), { width }))
+      await page.setExtraHTTPHeaders(merge.all([
+        this.configuration['request-headers'],
+        requestHeaders,
+      ]) as {})
+
       profile('--> assetDiscoveryService.page.goto', { url: rootResourceUrl })
       await page.goto(rootResourceUrl)
       profile('--> assetDiscoveryService.page.goto')


### PR DESCRIPTION
## Purpose

Sometimes, due to various reasons, the running browser might disconnect from Puppeteer during asset discovery causing a `target closed` error. This error can happen anytime CDP sends a message to the browser, such as enabling JS or setting viewport options. Since it is unhandled it can result in the local server being unable to respond to requests which can then result in request timeouts.

## Approach

Within asset discovery, move any interaction with the `page` object into an error handler. The various request event registrations do not have to be protected since they are generic event emitter registration methods.

I also noticed that none of the methods within the snapshot handler were protected, which might contribute to the server hanging since it does not respond for unhandled async errors by default. I wrapped the snapshot method with another try-catch to help ensure that the server responds when an error is encountered.