### PR TITLE
fix(📌): Unpin puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/agent",
   "description": "An agent process for integrating with Percy.",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "author": "Perceptual Inc",
   "bin": {
     "percy": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "image-size": "^0.8.2",
     "js-yaml": "^3.13.1",
     "percy-client": "^3.2.0",
-    "puppeteer": "5.0.0",
+    "puppeteer": "^5.3.1",
     "retry-axios": "^1.0.1",
     "which": "^2.0.1",
     "winston": "^3.0.0"

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -86,7 +86,7 @@ describe('Integration test', () => {
 
     it('snapshots a site with redirected assets', async () => {
       await page.goto('https://sdk-test.percy.dev/redirects/')
-      await page.waitFor('h2')
+      await page.waitForSelector('h2')
       const domSnapshot = await snapshot(page, 'Redirects snapshot')
 
       // This will fail the test if the redirected JS fails to work
@@ -237,10 +237,10 @@ describe('Integration test', () => {
     describe('canvas', () => {
       it('captures canvas elements', async () => {
         await page.goto(`http://localhost:${PORT}/serialize-canvas.html`)
-        await page.waitFor('#webgl canvas')
+        await page.waitForSelector('#webgl canvas')
         // I cannot think of a nicer way to let the canvas animations/drawing settle
         // so sadly, use a timeout
-        await page.waitFor(1000)
+        await page.waitForTimeout(1000)
         const domSnapshot = await snapshot(page, 'Canvas elements')
         const $ = cheerio.load(domSnapshot)
 
@@ -249,8 +249,8 @@ describe('Integration test', () => {
 
       it("doesn't serialize with JS enabled", async () => {
         await page.goto(`http://localhost:${PORT}/serialize-canvas.html`)
-        await page.waitFor('#webgl canvas')
-        await page.waitFor(1000)
+        await page.waitForSelector('#webgl canvas')
+        await page.waitForTimeout(1000)
         const domSnapshot = await snapshot(page, 'Canvas elements -- with JS', { enableJavaScript: true })
         const $ = cheerio.load(domSnapshot)
 

--- a/test/integration/agent-integration.test.ts
+++ b/test/integration/agent-integration.test.ts
@@ -240,6 +240,7 @@ describe('Integration test', () => {
         await page.waitForSelector('#webgl canvas')
         // I cannot think of a nicer way to let the canvas animations/drawing settle
         // so sadly, use a timeout
+        // @ts-ignore - this type doesn't exist, but the method does
         await page.waitForTimeout(1000)
         const domSnapshot = await snapshot(page, 'Canvas elements')
         const $ = cheerio.load(domSnapshot)
@@ -250,6 +251,7 @@ describe('Integration test', () => {
       it("doesn't serialize with JS enabled", async () => {
         await page.goto(`http://localhost:${PORT}/serialize-canvas.html`)
         await page.waitForSelector('#webgl canvas')
+        // @ts-ignore - this type doesn't exist, but the method does
         await page.waitForTimeout(1000)
         const domSnapshot = await snapshot(page, 'Canvas elements -- with JS', { enableJavaScript: true })
         const $ = cheerio.load(domSnapshot)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3374,6 +3374,11 @@ detective@^5.0.2:
     defined "^1.0.0"
     minimist "^1.1.1"
 
+devtools-protocol@0.0.799653:
+  version "0.0.799653"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.799653.tgz#86fc95ce5bf4fdf4b77a58047ba9d2301078f119"
+  integrity sha512-t1CcaZbvm8pOlikqrsIM9GOa7Ipp07+4h/q9u0JXBWjPCjHdBl9KkddX87Vv9vBHoBGtwV79sYQNGnQM6iS5gg==
+
 di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
@@ -6224,7 +6229,7 @@ mime@1.6.0, mime@^1.2.9, mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3, mime@^2.3.1, mime@^2.4.2:
+mime@^2.3.1, mime@^2.4.2:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
@@ -6304,11 +6309,6 @@ mississippi@^3.0.0:
     pumpify "^1.3.3"
     stream-each "^1.1.0"
     through2 "^2.0.0"
-
-mitt@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-2.1.0.tgz#f740577c23176c6205b121b2973514eade1b2230"
-  integrity sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -7340,16 +7340,15 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.0.0.tgz#7cf1b1a5c5b6ce5d7abe4d9c9f206d4c52e214ff"
-  integrity sha512-JnZcgRQnfowRSJoSHteKU7G9fP/YYGB/juPn8m4jNqtzvR0h8GOoFmdjTBesJFfzhYkPU1FosHXnBVUB++xgaA==
+puppeteer@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.3.1.tgz#324e190d89f25ac33dba539f57b82a18553f8646"
+  integrity sha512-YTM1RaBeYrj6n7IlRXRYLqJHF+GM7tasbvrNFx6w1S16G76NrPq7oYFKLDO+BQsXNtS8kW2GxWCXjIMPvfDyaQ==
   dependencies:
     debug "^4.1.0"
+    devtools-protocol "0.0.799653"
     extract-zip "^2.0.0"
     https-proxy-agent "^4.0.0"
-    mime "^2.0.3"
-    mitt "^2.0.1"
     pkg-dir "^4.2.0"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"


### PR DESCRIPTION
## Purpose

In #539, Puppeteer was pinned to a version that was known not to cause browser crashes. Turns out, that that version also crashes, but only in Docker containers where the default shared memory size is too small to properly run Chromium.

Puppeteer passes along the `--disable-dev-shm-usage` flag to Chromium to avoid this issue, but the current pinned Puppeteer version uses Chromium 83 which has a bug that causes it to ignore that flag. https://bugs.chromium.org/p/chromium/issues/detail?id=1085829

## Approach

Newer versions of Puppeteer have come out since we pinned it. This PR unpins it again to use the latest version which seems to avoid other issues outlined in #539 such as missing woff assets.


🤞 

---

This also bumps the version so we can quickly release this soon after merging