### PR TITLE
fix: `toString` PID number for `writeFileSync` (second arg requires string)

### DIFF
--- a/src/services/process-service.ts
+++ b/src/services/process-service.ts
@@ -49,6 +49,6 @@ export default class ProcessService {
   }
 
   private writePidFile(pid: number) {
-    fs.writeFileSync(ProcessService.PID_PATH, pid)
+    fs.writeFileSync(ProcessService.PID_PATH, pid.toString())
   }
 }


### PR DESCRIPTION
## What is this?

Node 14 will no longer coerce incorrect types given to `writeFileSync`.

![image](https://user-images.githubusercontent.com/2072894/95919922-0ff4c900-0d74-11eb-83ad-c7626adb456f.png)


The error thrown:

```
TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number
```