### PR TITLE
build(deps): upgrade puppeteer to v9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "image-size": "^0.8.2",
     "js-yaml": "^3.13.1",
     "percy-client": "^3.2.0",
-    "puppeteer": "^5.3.1",
+    "puppeteer": "^9.0.0",
     "retry-axios": "^1.0.1",
     "which": "^2.0.1",
     "winston": "^3.0.0"
@@ -66,7 +66,6 @@
     "@types/mocha": "^7.0.1",
     "@types/nock": "^11.1.0",
     "@types/node": "^13.7.0",
-    "@types/puppeteer": "^5.4.0",
     "@types/sinon": "^9.0.0",
     "@types/sinon-chai": "^3.2.0",
     "@types/which": "^1.3.2",


### PR DESCRIPTION
TypeScript typings are included in this version, so @types/puppeteer has been removed