### PR TITLE
fix: Lock colors.js to prevent infinite loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@oclif/plugin-not-found": "^1.2",
     "axios": "^0.21.1",
     "body-parser": "^1.18.3",
-    "colors": "^1.3.2",
+    "colors": "1.4.0",
     "cors": "^2.8.4",
     "cosmiconfig": "^5.2.1",
     "cross-spawn": "^7.0.2",


### PR DESCRIPTION
It seems that the lock file has it at 1.4.0 from this commit https://github.com/percy/percy-agent/commit/27127097c8b821fb175c9c8e2e49e31f5a79284c#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR2876

The later versions of colors have an infinite loop added, see references below

References
- https://github.com/Marak/colors.js/commit/074a0f8ed0c31c35d13d28632bd8a049ff136fb6?s=09#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R18
- https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected

Locking this to a known good version should give us capability back while migrations to the newer SDK are still underway